### PR TITLE
Fix issue with BTC UTXO selection logic

### DIFF
--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -69,12 +69,14 @@ export async function generateSignedBtcTransaction(
   const p2wpkh = payments.p2wpkh({ pubkey: keyPair.publicKey, network });
   const p2sh = payments.p2sh({ redeem: p2wpkh, network });
   const utxos = await fetchBtcAddressUnspent(senderAddress, selectedNetwork);
-  const psbt = new Psbt({ network });
-  const selectedUnspentOutputs = selectUnspentOutputs(amountSats, utxos);
-  const sumValue = sumUnspentOutputs(selectedUnspentOutputs);
-  const changeSats = sumValue.minus(amountSats).minus(fee);
 
-  if (sumValue.isLessThan(amountSats.plus(fee))) {
+  const totalAmountSats = amountSats.plus(fee);
+  const psbt = new Psbt({ network });
+  const selectedUnspentOutputs = selectUnspentOutputs(totalAmountSats, utxos);
+  const sumValue = sumUnspentOutputs(selectedUnspentOutputs);
+  const changeSats = sumValue.minus(totalAmountSats);
+
+  if (sumValue.isLessThan(totalAmountSats)) {
      throw new Error('Insufficient balance when including transaction fees');
    }
 


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
A bug in the BTC transaction generation logic causes fewer unspent transaction outputs (UTXO) to be selected than is needed because the transaction fee was not taken into account. This results in an insufficient balance error or potentially other errors when creating a Bitcoin transaction.

# What is the new behavior?
BTC transaction generation logic now takes into account transaction fees when selecting UTXOs.
