### PR TITLE
Update pool info function

### DIFF
--- a/api/xverse.ts
+++ b/api/xverse.ts
@@ -93,9 +93,8 @@ export async function fetchAppInfo(): Promise<FeesMultipliers | null> {
     });
 }
 
-export async function fetchStackingPoolInfo(source?: string): Promise<StackingPoolInfo> {
-  const sourceQueryParam: string = source ? `?source=${source}` : '';
-  return fetch(`${XVERSE_API_BASE_URL}/v1/pool/info${sourceQueryParam}`, {
+export async function fetchStackingPoolInfo(): Promise<StackingPoolInfo> {
+  return fetch(`${XVERSE_API_BASE_URL}/v1/pool/info?pool_version=3`, {
     method: 'GET',
   })
     .then((response) => response.json())


### PR DESCRIPTION
The function now accepts a parameter `source`. The xverse-app will pass the source as `app` inorder for the api to know the latest version is calling the endpoint and returns the pool open/close info

Works with [PR](https://github.com/secretkeylabs/xverse-api/pull/138) on the api side