### PR TITLE
Improve PSBT signing error messages

### DIFF
--- a/transactions/psbt.ts
+++ b/transactions/psbt.ts
@@ -229,7 +229,11 @@ export function parsePsbt(
 
   inputsToSign.forEach(inputToSign => {
     inputToSign.signingIndexes.forEach(index => {
-      inputs[index].userSigns = true;
+      if(inputs.length >= index) {
+        inputs[index].userSigns = true;
+      } else {
+        throw new Error('Signing index out of range')
+      }
     })
   })
 


### PR DESCRIPTION
This adds an error message when the requested signing index for PSBT is out of range.

And removes "hex" from PSBT parsing errors.