### PR TITLE
filter unspent outputs using ordinals utxos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "0.23.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "0.23.2",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@noble/secp256k1": "^1.7.1",

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -742,7 +742,8 @@ describe('bitcoin transactions', () => {
       btcAddress,
       0,
       testSeed,
-      network
+      network,
+      [ordinalOutputs[0]]
     );
 
     const { fee } = await getFee(
@@ -821,7 +822,7 @@ describe('bitcoin transactions', () => {
       regular: 10,
       priority: 30,
     };
-    
+
     fetchFeeRateSpy.mockImplementation(() => Promise.resolve(feeRate));
 
     const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');
@@ -838,7 +839,8 @@ describe('bitcoin transactions', () => {
       btcAddress,
       0,
       testSeed,
-      network
+      network,
+      [ordinalOutputs[0]]
     );
 
     const expectedTx =
@@ -919,7 +921,8 @@ describe('bitcoin transactions', () => {
       0,
       testSeed,
       network,
-      customFeeAmount
+      [ordinalOutputs[0]],
+      customFeeAmount,
     );
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(0);

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -676,10 +676,7 @@ export async function signOrdinalSendTransaction(
   // This can be true if ordinal utxo is from the payment address
 
 
-  const filteredUnspentOutputs = [
-    ...filterUtxos(unspentOutputs, addressOrdinalsUtxos),
-    ...filterUtxos(addressOrdinalsUtxos, unspentOutputs),
-  ];
+  const filteredUnspentOutputs = filterUtxos(unspentOutputs, addressOrdinalsUtxos);
 
   let ordinalUtxoInPaymentAddress = false;
   if (filteredUnspentOutputs.length < unspentOutputs.length) {

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -226,8 +226,8 @@ export async function getBtcFees(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-): Promise<{fee: BigNumber, selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
     const btcClient = new BitcoinEsploraApiProvider({
       network,
@@ -267,7 +267,7 @@ export async function getBtcFees(
       feeMode
     );
 
-    return {fee, selectedFeeRate};
+    return { fee, selectedFeeRate };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -281,13 +281,13 @@ export async function getBtcFeesForOrdinalSend(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-  ): Promise<{fee: BigNumber; selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const unspentOutputs = await btcClient.getUnspentUtxos(btcAddress);
+    const btcClient = new BitcoinEsploraApiProvider({
+      network,
+    });
+    const unspentOutputs = await btcClient.getUnspentUtxos(btcAddress);
 
     let feeRate: BtcFeeResponse = defaultFeeRate;
 
@@ -328,7 +328,7 @@ export async function getBtcFeesForOrdinalSend(
       feeMode
     );
 
-    return {fee, selectedFeeRate};
+    return { fee, selectedFeeRate };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -342,8 +342,8 @@ export async function getBtcFeesForNonOrdinalBtcSend(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-  ): Promise<{fee: BigNumber; selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
     const unspentOutputs = nonOrdinalUtxos;
 
@@ -383,7 +383,7 @@ export async function getBtcFeesForNonOrdinalBtcSend(
       network
     );
 
-    return {fee: calculatedFee, selectedFeeRate: new BigNumber(feeRateInput || selectedFeeRate)};
+    return { fee: calculatedFee, selectedFeeRate: new BigNumber(feeRateInput || selectedFeeRate) };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -408,7 +408,7 @@ export async function getFee(
   let i_selectedUnspentOutputs = selectedUnspentOutputs.slice();
 
   let selectedFeeRate = Number(feeRate);
-  
+
   if (typeof feeRate === 'object') {
     selectedFeeRate = feeRate.regular;
 
@@ -602,7 +602,11 @@ export async function signBtcTransaction(
   // Calculate transaction fee
   let calculatedFee: BigNumber = new BigNumber(0);
   if (!fee) {
-    const { newSelectedUnspentOutputs, fee: modifiedFee, selectedFeeRate } = await getFee(
+    const {
+      newSelectedUnspentOutputs,
+      fee: modifiedFee,
+      selectedFeeRate,
+    } = await getFee(
       unspentOutputs,
       selectedUnspentOutputs,
       sumSelectedOutputs,
@@ -645,6 +649,11 @@ export async function signBtcTransaction(
   }
 }
 
+  function filterUtxos(array1: UTXO[], array2: UTXO[]) {
+    return array1.filter((object1) => !array2.some((object2) => object1.txid === object2.txid));
+  }
+
+
 export async function signOrdinalSendTransaction(
   recipientAddress: string,
   ordinalUtxo: UTXO,
@@ -652,7 +661,8 @@ export async function signOrdinalSendTransaction(
   accountIndex: number,
   seedPhrase: string,
   network: NetworkType,
-  fee?: BigNumber
+  fee?: BigNumber,
+  addressOrdinalsUtxos?: UTXO[]
 ): Promise<SignedBtcTx> {
   // Get sender address unspent outputs
   const btcClient = new BitcoinEsploraApiProvider({
@@ -662,11 +672,12 @@ export async function signOrdinalSendTransaction(
 
   // Make sure ordinal utxo is removed from utxo set used for fees
   // This can be true if ordinal utxo is from the payment address
-  const filteredUnspentOutputs = unspentOutputs.filter((unspentOutput) => {
-    return !(
-      unspentOutput.txid === ordinalUtxo.txid && unspentOutput.vout === ordinalUtxo.vout
-    );
-  });
+
+
+  const filteredUnspentOutputs = [
+    ...filterUtxos(unspentOutputs, addressOrdinalsUtxos!),
+    ...filterUtxos(addressOrdinalsUtxos!, unspentOutputs),
+  ];
 
   let ordinalUtxoInPaymentAddress = false;
   if (filteredUnspentOutputs.length < unspentOutputs.length) {
@@ -723,7 +734,11 @@ export async function signOrdinalSendTransaction(
   // Calculate transaction fee
   let calculatedFee: BigNumber = new BigNumber(0);
   if (!fee) {
-    const { newSelectedUnspentOutputs, fee: modifiedFee, selectedFeeRate } = await getFee(
+    const {
+      newSelectedUnspentOutputs,
+      fee: modifiedFee,
+      selectedFeeRate,
+    } = await getFee(
       filteredUnspentOutputs,
       selectedUnspentOutputs,
       sumSelectedOutputs,

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -649,8 +649,10 @@ export async function signBtcTransaction(
   }
 }
 
-  function filterUtxos(array1: UTXO[], array2: UTXO[]) {
-    return array1.filter((object1) => !array2.some((object2) => object1.txid === object2.txid));
+  function filterUtxos(allUtxos: UTXO[], filterUtxoSet: UTXO[]) {
+    return allUtxos.filter(
+      (utxo) => !filterUtxoSet.some((filterUtxo) => utxo.txid === filterUtxo.txid)
+    );
   }
 
 
@@ -661,8 +663,8 @@ export async function signOrdinalSendTransaction(
   accountIndex: number,
   seedPhrase: string,
   network: NetworkType,
+  addressOrdinalsUtxos: UTXO[],
   fee?: BigNumber,
-  addressOrdinalsUtxos?: UTXO[]
 ): Promise<SignedBtcTx> {
   // Get sender address unspent outputs
   const btcClient = new BitcoinEsploraApiProvider({
@@ -675,8 +677,8 @@ export async function signOrdinalSendTransaction(
 
 
   const filteredUnspentOutputs = [
-    ...filterUtxos(unspentOutputs, addressOrdinalsUtxos!),
-    ...filterUtxos(addressOrdinalsUtxos!, unspentOutputs),
+    ...filterUtxos(unspentOutputs, addressOrdinalsUtxos),
+    ...filterUtxos(addressOrdinalsUtxos, unspentOutputs),
   ];
 
   let ordinalUtxoInPaymentAddress = false;


### PR DESCRIPTION
`signOrdinalSendTransaction` function is updated to take the a list of the address ordinals utxo to filter them out from the unspent outputs used to construct the transfer tx