### PR TITLE
Fix incorrect BTC fee

### DIFF
--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -562,19 +562,6 @@ describe('bitcoin transactions', () => {
           confirmed: true,
         },
         txid: '8b330459af5329c06f8950fda313bbf2e51afc868e3b31c0e1a7acbca2fdffe6',
-        value: 5700,
-        vout: 0,
-      },
-      {
-        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
-        blockHeight: 793556,
-        status: {
-          block_hash: '00000000000000000000a46de80f72757343c538d13be3a992aa733fe33bc4bb',
-          block_height: 793556,
-          block_time: 1686310361,
-          confirmed: true,
-        },
-        txid: '8b330459af5329c06f8950fda313bbf2e51afc868e3b31c0e1a7acbca2fdffe6',
         value: 3911,
         vout: 1,
       },
@@ -593,6 +580,19 @@ describe('bitcoin transactions', () => {
       },
       {
         address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 793556,
+        status: {
+          block_hash: '00000000000000000000a46de80f72757343c538d13be3a992aa733fe33bc4bb',
+          block_height: 793556,
+          block_time: 1686310361,
+          confirmed: true,
+        },
+        txid: '8b330459af5329c06f8950fda313bbf2e51afc868e3b31c0e1a7acbca2fdffe6',
+        value: 5700,
+        vout: 0,
+      },
+      {
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
         blockHeight: 792930,
         status: {
           block_hash: '0000000000000000000026351fde98eb0b9a3e6e3ea8feceef13186e719c91f5',
@@ -606,7 +606,7 @@ describe('bitcoin transactions', () => {
       },
     ];
 
-    const recipient1Amount = 6000;
+    const recipient1Amount = 60000;
     const recipient2Amount = 50000;
     const satsToSend = recipient1Amount + recipient2Amount;
 
@@ -628,9 +628,10 @@ describe('bitcoin transactions', () => {
     const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');
     fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos));
 
+    //const signedBtc = await signBtcTransaction(recipients, btcAddress, 0, testSeed, network);
     await expect(async () => {
       await signBtcTransaction(recipients, btcAddress, 0, testSeed, network);
-    }).rejects.toThrowError(new Error('No inputs signed'));
+    }).rejects.toThrowError('601');
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(1);
     expect(fetchUtxoSpy).toHaveBeenCalledTimes(1);
@@ -905,7 +906,7 @@ describe('bitcoin transactions', () => {
       testSeed,
       network,
       [ordinalOutputs[0]],
-      customFeeAmount,
+      customFeeAmount
     );
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(0);

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -11,10 +11,11 @@ import {
   selectUnspentOutputs,
   getFee,
   sumUnspentOutputs,
+  filterUtxos,
 } from '../../transactions/btc';
 import { getBtcPrivateKey } from '../../wallet';
 import { testSeed } from '../mocks/restore.mock';
-import { BtcUtxoDataResponse, ErrorCodes, ResponseError, UTXO } from '../../types';
+import { UTXO } from '../../types';
 import BigNumber from 'bignumber.js';
 import * as XverseAPIFunctions from '../../api/xverse';
 import BitcoinEsploraApiProvider from '../../api/esplora/esploraAPiProvider';
@@ -705,12 +706,7 @@ describe('bitcoin transactions', () => {
       },
     ];
 
-    const filteredUnspentOutputs = utxos.filter((unspentOutput) => {
-      return !(
-        unspentOutput.txid === ordinalOutputs[0].txid &&
-        unspentOutput.vout === ordinalOutputs[0].vout
-      );
-    });
+    const filteredUnspentOutputs = filterUtxos(utxos, [ordinalOutputs[0]]);
 
     let selectedUnspentOutputs = selectUnspentOutputs(
       new BigNumber(ordinalOutputs[0].value),

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -161,58 +161,45 @@ describe('bitcoin transactions', () => {
     const unspent3Value = 250000;
     const totalUnspentValue = unspent1Value + unspent2Value + unspent3Value;
 
-    const utxos: Array<UTXO> = [
+    const utxos: Array<UTXO & { address: string; blockHeight?: number }> = [
       {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8c',
-        vout: 2,
+        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
+        blockHeight: 794591,
         status: {
+          block_hash: '00000000000000000000c46287836d6018f1e6b2c02e33bd60e5c0681bcfe211',
+          block_height: 794591,
+          block_time: 1686905456,
           confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        value: unspent1Value,
+        txid: '555a4d6147848f6798af06a716d641a15fa118df68f995521f0327d0ad7f56e5',
+        value: 290842,
+        vout: 1,
       },
       {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8d',
-        vout: 2,
+        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
+        blockHeight: 794590,
         status: {
+          block_hash: '00000000000000000001f6ad0390dbb0d586662de872fbdcff8e2b4aa8fcd848',
+          block_height: 794590,
+          block_time: 1686904928,
           confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        value: unspent2Value,
-      },
-      {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8e',
-        vout: 2,
-        status: {
-          confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
-        },
-        value: unspent3Value,
+        txid: '064829354f7280f9031b289faab8a4cdc2e38865d3495f3c9a0101218249194b',
+        value: 247106,
+        vout: 1,
       },
     ];
 
-    const recipient1Amount = 200000;
-    const recipient2Amount = 100000;
-    const satsToSend = recipient1Amount + recipient2Amount;
+    const recipient1Amount = 6000;
 
     const recipients: Array<Recipient> = [
       {
-        address: '1QBwMVYH4efRVwxydnwoGwELJoi47FuRvS',
+        address: '3FijEEhojeNqpt62bKbTbj3zvwghfwcPwK',
         amountSats: new BigNumber(recipient1Amount),
-      },
-      {
-        address: '18xdKbDgTKjTZZ9jpbrPax8X4qZeHG6b65',
-        amountSats: new BigNumber(recipient2Amount),
       },
     ];
 
-    const changeAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
+    const changeAddress = '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U';
 
     const fetchFeeRateSpy = vi.spyOn(XverseAPIFunctions, 'fetchBtcFeeRate');
     const feeRate = defaultFeeRate;
@@ -221,10 +208,10 @@ describe('bitcoin transactions', () => {
     const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');
     fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos));
 
-    const {fee} = await getBtcFees(recipients, changeAddress, network);
+    const { fee } = await getBtcFees(recipients, changeAddress, network);
 
     // expect transaction size to be 385 bytes;
-    const txSize = 385;
+    const txSize = 166;
     expect(fee.toNumber()).eq(txSize * feeRate.regular);
   });
 
@@ -246,7 +233,7 @@ describe('bitcoin transactions', () => {
           block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
         value: ordinalValue,
-      }
+      },
     ];
 
     const utxos: Array<UTXO> = [
@@ -276,7 +263,7 @@ describe('bitcoin transactions', () => {
     const ordinalAddress = 'bc1prtztqsgks2l6yuuhgsp36lw5n6dzpkj287lesqnfgktzqajendzq3p9urw';
     const btcAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
-    const {fee} = await getBtcFeesForOrdinalSend(
+    const { fee } = await getBtcFeesForOrdinalSend(
       recipientAddress,
       ordinalOutputs[0],
       btcAddress,
@@ -296,60 +283,51 @@ describe('bitcoin transactions', () => {
     const unspent3Value = 250000;
     const totalUnspentValue = unspent1Value + unspent2Value + unspent3Value;
 
-    const selectedUnspentOutputs: Array<UTXO> = [
+    const utxos: Array<UTXO & { address: string; blockHeight?: number }> = [
       {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8c',
-        vout: 2,
+        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
+        blockHeight: 794591,
         status: {
+          block_hash: '00000000000000000000c46287836d6018f1e6b2c02e33bd60e5c0681bcfe211',
+          block_height: 794591,
+          block_time: 1686905456,
           confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        value: unspent1Value,
+        txid: '555a4d6147848f6798af06a716d641a15fa118df68f995521f0327d0ad7f56e5',
+        value: 290842,
+        vout: 1,
       },
       {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8d',
-        vout: 2,
+        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
+        blockHeight: 794590,
         status: {
+          block_hash: '00000000000000000001f6ad0390dbb0d586662de872fbdcff8e2b4aa8fcd848',
+          block_height: 794590,
+          block_time: 1686904928,
           confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        value: unspent2Value,
-      },
-      {
-        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8e',
-        vout: 2,
-        status: {
-          confirmed: true,
-          block_height: 123123,
-          block_time: 1677048365,
-          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
-        },
-        value: unspent3Value,
+        txid: '064829354f7280f9031b289faab8a4cdc2e38865d3495f3c9a0101218249194b',
+        value: 247106,
+        vout: 1,
       },
     ];
 
-    const recipient1Amount = 200000;
+    const recipient1Amount = 6000;
     const recipient2Amount = 100000;
-    const satsToSend = recipient1Amount + recipient2Amount;
+    const satsToSend = recipient1Amount;
 
     const recipients: Array<Recipient> = [
       {
-        address: '1QBwMVYH4efRVwxydnwoGwELJoi47FuRvS',
+        address: '3FijEEhojeNqpt62bKbTbj3zvwghfwcPwK',
         amountSats: new BigNumber(recipient1Amount),
-      },
-      {
-        address: '18xdKbDgTKjTZZ9jpbrPax8X4qZeHG6b65',
-        amountSats: new BigNumber(recipient2Amount),
       },
     ];
 
-    const changeAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
+    const changeAddress = '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U';
 
     const feeRate = defaultFeeRate;
+
+    const selectedUnspentOutputs = selectUnspentOutputs(new BigNumber(satsToSend), utxos);
 
     const fee = await calculateFee(
       selectedUnspentOutputs,
@@ -361,7 +339,7 @@ describe('bitcoin transactions', () => {
     );
 
     // expect transaction size to be 385 bytes;
-    const txSize = 385;
+    const txSize = 166;
     expect(fee.toNumber()).eq(txSize * feeRate.regular);
   });
 
@@ -558,96 +536,100 @@ describe('bitcoin transactions', () => {
   });
 
   it('fails to create transaction when insufficient balance after adding fees', async () => {
-    const network = "Mainnet";
+    const network = 'Mainnet';
 
-    const unspent1Value = 100000;
-    const unspent2Value = 1800;
-    const unspent3Value = 1000;
-    const totalUnspentValue = unspent1Value +  + unspent2Value + unspent3Value;
-
-    const utxos: Array<BtcUtxoDataResponse> = [
+    const utxos: Array<UTXO & { address: string; blockHeight?: number }> = [
       {
-        tx_hash: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8c',
-        block_height: 123123,
-        tx_input_n: -1,
-        tx_output_n: 2,
-        value: unspent1Value,
-        ref_balance: 123123123,
-        spent: false,
-        confirmations: 100000,
-        confirmed: "2020-02-20T02:02:22Z",
-        double_spend: false,
-        double_spend_tx: "asdf",
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 794533,
+        status: {
+          block_hash: '0000000000000000000437fc3765a3685b4dc7e2568221ef73a6642bc3ce09fb',
+          block_height: 794533,
+          block_time: 1686877112,
+          confirmed: true,
+        },
+        txid: '357cd8a47fb6c5b9820c8fa9e7dd5ea1a588ada41761b303f87464d8faa352cd',
+        value: 5500,
+        vout: 0,
       },
       {
-        tx_hash: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8d',
-        block_height: 123123,
-        tx_input_n: -1,
-        tx_output_n: 2,
-        value: unspent2Value,
-        ref_balance: 123123123,
-        spent: false,
-        confirmations: 100000,
-        confirmed: "2020-02-20T02:02:22Z",
-        double_spend: false,
-        double_spend_tx: "asdf",
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 793556,
+        status: {
+          block_hash: '00000000000000000000a46de80f72757343c538d13be3a992aa733fe33bc4bb',
+          block_height: 793556,
+          block_time: 1686310361,
+          confirmed: true,
+        },
+        txid: '8b330459af5329c06f8950fda313bbf2e51afc868e3b31c0e1a7acbca2fdffe6',
+        value: 5700,
+        vout: 0,
       },
       {
-        tx_hash: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8e',
-        block_height: 123123,
-        tx_input_n: -1,
-        tx_output_n: 2,
-        value: unspent3Value,
-        ref_balance: 123123123,
-        spent: false,
-        confirmations: 100000,
-        confirmed: "2020-02-20T02:02:22Z",
-        double_spend: false,
-        double_spend_tx: "asdf",
-      }
-    ]
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 793556,
+        status: {
+          block_hash: '00000000000000000000a46de80f72757343c538d13be3a992aa733fe33bc4bb',
+          block_height: 793556,
+          block_time: 1686310361,
+          confirmed: true,
+        },
+        txid: '8b330459af5329c06f8950fda313bbf2e51afc868e3b31c0e1a7acbca2fdffe6',
+        value: 3911,
+        vout: 1,
+      },
+      {
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 793974,
+        status: {
+          block_hash: '000000000000000000048adca1cd3d995e783f8dda3ce094d0feb0fa7ad35926',
+          block_height: 793974,
+          block_time: 1686540100,
+          confirmed: true,
+        },
+        txid: '30ff5258040579963b58f066a48daeed5f695329c0afb89c055f72e166a69f42',
+        value: 941,
+        vout: 12,
+      },
+      {
+        address: '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe',
+        blockHeight: 792930,
+        status: {
+          block_hash: '0000000000000000000026351fde98eb0b9a3e6e3ea8feceef13186e719c91f5',
+          block_height: 792930,
+          block_time: 1685945805,
+          confirmed: true,
+        },
+        txid: 'c761835d87e382037e2628431821cfa9a56811a02a0cb4032eb81b72ae9c6b32',
+        value: 1510,
+        vout: 1,
+      },
+    ];
 
-    const recipient1Amount = 50000;
+    const recipient1Amount = 6000;
     const recipient2Amount = 50000;
-    const satsToSend = recipient1Amount+recipient2Amount;
+    const satsToSend = recipient1Amount + recipient2Amount;
 
     const recipients: Array<Recipient> = [
       {
-        address: "1QBwMVYH4efRVwxydnwoGwELJoi47FuRvS",
+        address: '3FijEEhojeNqpt62bKbTbj3zvwghfwcPwK',
         amountSats: new BigNumber(recipient1Amount),
       },
-      {
-        address: "18xdKbDgTKjTZZ9jpbrPax8X4qZeHG6b65",
-        amountSats: new BigNumber(recipient2Amount),
-      }
-    ]
+    ];
 
-    const btcAddress = "1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT";
+    const btcAddress = '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe';
 
-    const fetchFeeRateSpy = vi.spyOn(XverseAPIFunctions, 'fetchBtcFeeRate')
-    expect(fetchFeeRateSpy.getMockName()).toEqual('fetchBtcFeeRate')
-    const feeRate = {
-      limits: {
-        min: 1,
-        max: 5,
-      },
-      regular: 10,
-      priority: 30
-    }
+    const fetchFeeRateSpy = vi.spyOn(XverseAPIFunctions, 'fetchBtcFeeRate');
+    expect(fetchFeeRateSpy.getMockName()).toEqual('fetchBtcFeeRate');
+    const feeRate = defaultFeeRate;
 
     fetchFeeRateSpy.mockImplementation(() => Promise.resolve(feeRate));
 
-    const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos')
-    fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos))
+    const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');
+    fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos));
 
     await expect(async () => {
-      await signBtcTransaction(
-        recipients,
-        btcAddress,
-        0,
-        testSeed,
-        network
-      )
+      await signBtcTransaction(recipients, btcAddress, 0, testSeed, network);
     }).rejects.toThrowError(new Error('No inputs signed'));
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(1);
@@ -724,7 +706,8 @@ describe('bitcoin transactions', () => {
 
     const filteredUnspentOutputs = utxos.filter((unspentOutput) => {
       return !(
-        unspentOutput.txid === ordinalOutputs[0].txid && unspentOutput.vout === ordinalOutputs[0].vout
+        unspentOutput.txid === ordinalOutputs[0].txid &&
+        unspentOutput.vout === ordinalOutputs[0].vout
       );
     });
 
@@ -821,7 +804,7 @@ describe('bitcoin transactions', () => {
       regular: 10,
       priority: 30,
     };
-    
+
     fetchFeeRateSpy.mockImplementation(() => Promise.resolve(feeRate));
 
     const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -64,7 +64,7 @@ describe('bitcoin transactions', () => {
       satsToSend,
       recipients,
       changeAddress,
-      network
+      network,
     );
 
     expect(signedTx.inputs.length).eq(1);
@@ -144,7 +144,7 @@ describe('bitcoin transactions', () => {
       satsToSend,
       recipients,
       changeAddress,
-      network
+      network,
     );
 
     expect(signedTx.inputs.length).eq(3);
@@ -162,45 +162,58 @@ describe('bitcoin transactions', () => {
     const unspent3Value = 250000;
     const totalUnspentValue = unspent1Value + unspent2Value + unspent3Value;
 
-    const utxos: Array<UTXO & { address: string; blockHeight?: number }> = [
+    const utxos: Array<UTXO> = [
       {
-        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
-        blockHeight: 794591,
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8c',
+        vout: 2,
         status: {
-          block_hash: '00000000000000000000c46287836d6018f1e6b2c02e33bd60e5c0681bcfe211',
-          block_height: 794591,
-          block_time: 1686905456,
           confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        txid: '555a4d6147848f6798af06a716d641a15fa118df68f995521f0327d0ad7f56e5',
-        value: 290842,
-        vout: 1,
+        value: unspent1Value,
       },
       {
-        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
-        blockHeight: 794590,
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8d',
+        vout: 2,
         status: {
-          block_hash: '00000000000000000001f6ad0390dbb0d586662de872fbdcff8e2b4aa8fcd848',
-          block_height: 794590,
-          block_time: 1686904928,
           confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        txid: '064829354f7280f9031b289faab8a4cdc2e38865d3495f3c9a0101218249194b',
-        value: 247106,
-        vout: 1,
+        value: unspent2Value,
+      },
+      {
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8e',
+        vout: 2,
+        status: {
+          confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
+        },
+        value: unspent3Value,
       },
     ];
 
-    const recipient1Amount = 6000;
+    const recipient1Amount = 200000;
+    const recipient2Amount = 100000;
+    const satsToSend = recipient1Amount + recipient2Amount;
 
     const recipients: Array<Recipient> = [
       {
-        address: '3FijEEhojeNqpt62bKbTbj3zvwghfwcPwK',
+        address: '1QBwMVYH4efRVwxydnwoGwELJoi47FuRvS',
         amountSats: new BigNumber(recipient1Amount),
+      },
+      {
+        address: '18xdKbDgTKjTZZ9jpbrPax8X4qZeHG6b65',
+        amountSats: new BigNumber(recipient2Amount),
       },
     ];
 
-    const changeAddress = '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U';
+    const changeAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
     const fetchFeeRateSpy = vi.spyOn(XverseAPIFunctions, 'fetchBtcFeeRate');
     const feeRate = defaultFeeRate;
@@ -212,7 +225,7 @@ describe('bitcoin transactions', () => {
     const { fee } = await getBtcFees(recipients, changeAddress, network);
 
     // expect transaction size to be 385 bytes;
-    const txSize = 166;
+    const txSize = 385;
     expect(fee.toNumber()).eq(txSize * feeRate.regular);
   });
 
@@ -264,12 +277,7 @@ describe('bitcoin transactions', () => {
     const ordinalAddress = 'bc1prtztqsgks2l6yuuhgsp36lw5n6dzpkj287lesqnfgktzqajendzq3p9urw';
     const btcAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
-    const { fee } = await getBtcFeesForOrdinalSend(
-      recipientAddress,
-      ordinalOutputs[0],
-      btcAddress,
-      network
-    );
+    const { fee } = await getBtcFeesForOrdinalSend(recipientAddress, ordinalOutputs[0], btcAddress, network);
 
     // expect transaction size to be 260 bytes;
     const txSize = 260;
@@ -284,47 +292,58 @@ describe('bitcoin transactions', () => {
     const unspent3Value = 250000;
     const totalUnspentValue = unspent1Value + unspent2Value + unspent3Value;
 
-    const utxos: Array<UTXO & { address: string; blockHeight?: number }> = [
+    const utxos: Array<UTXO> = [
       {
-        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
-        blockHeight: 794591,
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8c',
+        vout: 2,
         status: {
-          block_hash: '00000000000000000000c46287836d6018f1e6b2c02e33bd60e5c0681bcfe211',
-          block_height: 794591,
-          block_time: 1686905456,
           confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        txid: '555a4d6147848f6798af06a716d641a15fa118df68f995521f0327d0ad7f56e5',
-        value: 290842,
-        vout: 1,
+        value: unspent1Value,
       },
       {
-        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
-        blockHeight: 794590,
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8d',
+        vout: 2,
         status: {
-          block_hash: '00000000000000000001f6ad0390dbb0d586662de872fbdcff8e2b4aa8fcd848',
-          block_height: 794590,
-          block_time: 1686904928,
           confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
         },
-        txid: '064829354f7280f9031b289faab8a4cdc2e38865d3495f3c9a0101218249194b',
-        value: 247106,
-        vout: 1,
+        value: unspent2Value,
+      },
+      {
+        txid: '1f2bbb92a74d379db2502e8ae7a57917041db5dc531ef54e64ca532aa9f59d8e',
+        vout: 2,
+        status: {
+          confirmed: true,
+          block_height: 123123,
+          block_time: 1677048365,
+          block_hash: '000000000000000000072266ee093771d806cc9cb384461841f9edd40b52b67f',
+        },
+        value: unspent3Value,
       },
     ];
 
-    const recipient1Amount = 6000;
+    const recipient1Amount = 200000;
     const recipient2Amount = 100000;
-    const satsToSend = recipient1Amount;
+    const satsToSend = recipient1Amount + recipient2Amount;
 
     const recipients: Array<Recipient> = [
       {
-        address: '3FijEEhojeNqpt62bKbTbj3zvwghfwcPwK',
+        address: '1QBwMVYH4efRVwxydnwoGwELJoi47FuRvS',
         amountSats: new BigNumber(recipient1Amount),
+      },
+      {
+        address: '18xdKbDgTKjTZZ9jpbrPax8X4qZeHG6b65',
+        amountSats: new BigNumber(recipient2Amount),
       },
     ];
 
-    const changeAddress = '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U';
+    const changeAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
     const feeRate = defaultFeeRate;
 
@@ -336,11 +355,11 @@ describe('bitcoin transactions', () => {
       recipients,
       new BigNumber(feeRate.regular),
       changeAddress,
-      network
+      network,
     );
 
     // expect transaction size to be 385 bytes;
-    const txSize = 166;
+    const txSize = 261;
     expect(fee.toNumber()).eq(txSize * feeRate.regular);
   });
 
@@ -522,14 +541,7 @@ describe('bitcoin transactions', () => {
     fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos));
     const customFees = new BigNumber(500);
 
-    const signedTx = await signBtcTransaction(
-      recipients,
-      btcAddress,
-      0,
-      testSeed,
-      network,
-      customFees
-    );
+    const signedTx = await signBtcTransaction(recipients, btcAddress, 0, testSeed, network, customFees);
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(0);
     expect(fetchUtxoSpy).toHaveBeenCalledTimes(1);
@@ -711,7 +723,7 @@ describe('bitcoin transactions', () => {
     let selectedUnspentOutputs = selectUnspentOutputs(
       new BigNumber(ordinalOutputs[0].value),
       filteredUnspentOutputs,
-      ordinalOutputs[0]
+      ordinalOutputs[0],
     );
 
     const sumSelectedOutputs = sumUnspentOutputs(selectedUnspentOutputs);
@@ -723,7 +735,7 @@ describe('bitcoin transactions', () => {
       0,
       testSeed,
       network,
-      [ordinalOutputs[0]]
+      [ordinalOutputs[0]],
     );
 
     const { fee } = await getFee(
@@ -735,7 +747,7 @@ describe('bitcoin transactions', () => {
       feeRate,
       btcAddress,
       network,
-      ordinalOutputs[0]
+      ordinalOutputs[0],
     );
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(1);
@@ -820,7 +832,7 @@ describe('bitcoin transactions', () => {
       0,
       testSeed,
       network,
-      [ordinalOutputs[0]]
+      [ordinalOutputs[0]],
     );
 
     const expectedTx =
@@ -902,7 +914,7 @@ describe('bitcoin transactions', () => {
       testSeed,
       network,
       [ordinalOutputs[0]],
-      customFeeAmount
+      customFeeAmount,
     );
 
     expect(fetchFeeRateSpy).toHaveBeenCalledTimes(0);

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -641,7 +641,6 @@ describe('bitcoin transactions', () => {
     const fetchUtxoSpy = vi.spyOn(BitcoinEsploraApiProvider.prototype, 'getUnspentUtxos');
     fetchUtxoSpy.mockImplementation(() => Promise.resolve(utxos));
 
-    //const signedBtc = await signBtcTransaction(recipients, btcAddress, 0, testSeed, network);
     await expect(async () => {
       await signBtcTransaction(recipients, btcAddress, 0, testSeed, network);
     }).rejects.toThrowError('601');

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -658,7 +658,7 @@ export async function signBtcTransaction(
   }
 }
 
-function filterUtxos(allUtxos: UTXO[], filterUtxoSet: UTXO[]) {
+export function filterUtxos(allUtxos: UTXO[], filterUtxoSet: UTXO[]) {
   return allUtxos.filter(
     (utxo) => !filterUtxoSet.some((filterUtxo) => utxo.txid === filterUtxo.txid)
   );

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -69,9 +69,13 @@ export function selectUnspentOutputs(
   unspentOutputs.sort((a, b) => {
     if (a.status.block_time && b.status.block_time) {
       return a.status.block_time - b.status.block_time;
+    } else if (a.status.block_time) {
+      return 1;
+    } else if (b.status.block_time) {
+      return -1;
+    } else {
+      return a.value - b.value;
     }
-    // Handle cases where block time is missing
-    return 0;
   });
 
   unspentOutputs.forEach((unspentOutput) => {

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -65,6 +65,15 @@ export function selectUnspentOutputs(
     sumValue += pinnedOutput.value;
   }
 
+  // Sort UTXOs based on block time in ascending order
+  unspentOutputs.sort((a, b) => {
+    if (a.status.block_time && b.status.block_time) {
+      return a.status.block_time - b.status.block_time;
+    }
+    // Handle cases where block time is missing
+    return 0;
+  });
+
   unspentOutputs.forEach((unspentOutput) => {
     if (amountSats.toNumber() > sumValue) {
       inputs.push(unspentOutput);
@@ -226,8 +235,8 @@ export async function getBtcFees(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-): Promise<{fee: BigNumber, selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
     const btcClient = new BitcoinEsploraApiProvider({
       network,
@@ -267,7 +276,7 @@ export async function getBtcFees(
       feeMode
     );
 
-    return {fee, selectedFeeRate};
+    return { fee, selectedFeeRate };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -281,13 +290,13 @@ export async function getBtcFeesForOrdinalSend(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-  ): Promise<{fee: BigNumber; selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const unspentOutputs = await btcClient.getUnspentUtxos(btcAddress);
+    const btcClient = new BitcoinEsploraApiProvider({
+      network,
+    });
+    const unspentOutputs = await btcClient.getUnspentUtxos(btcAddress);
 
     let feeRate: BtcFeeResponse = defaultFeeRate;
 
@@ -328,7 +337,7 @@ export async function getBtcFeesForOrdinalSend(
       feeMode
     );
 
-    return {fee, selectedFeeRate};
+    return { fee, selectedFeeRate };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -342,8 +351,8 @@ export async function getBtcFeesForNonOrdinalBtcSend(
   btcAddress: string,
   network: NetworkType,
   feeMode?: string,
-  feeRateInput?: string,
-  ): Promise<{fee: BigNumber; selectedFeeRate?: BigNumber}> {
+  feeRateInput?: string
+): Promise<{ fee: BigNumber; selectedFeeRate?: BigNumber }> {
   try {
     const unspentOutputs = nonOrdinalUtxos;
 
@@ -383,7 +392,7 @@ export async function getBtcFeesForNonOrdinalBtcSend(
       network
     );
 
-    return {fee: calculatedFee, selectedFeeRate: new BigNumber(feeRateInput || selectedFeeRate)};
+    return { fee: calculatedFee, selectedFeeRate: new BigNumber(feeRateInput || selectedFeeRate) };
   } catch (error) {
     return Promise.reject(error.toString());
   }
@@ -408,7 +417,7 @@ export async function getFee(
   let i_selectedUnspentOutputs = selectedUnspentOutputs.slice();
 
   let selectedFeeRate = Number(feeRate);
-  
+
   if (typeof feeRate === 'object') {
     selectedFeeRate = feeRate.regular;
 
@@ -602,7 +611,11 @@ export async function signBtcTransaction(
   // Calculate transaction fee
   let calculatedFee: BigNumber = new BigNumber(0);
   if (!fee) {
-    const { newSelectedUnspentOutputs, fee: modifiedFee, selectedFeeRate } = await getFee(
+    const {
+      newSelectedUnspentOutputs,
+      fee: modifiedFee,
+      selectedFeeRate,
+    } = await getFee(
       unspentOutputs,
       selectedUnspentOutputs,
       sumSelectedOutputs,
@@ -663,9 +676,7 @@ export async function signOrdinalSendTransaction(
   // Make sure ordinal utxo is removed from utxo set used for fees
   // This can be true if ordinal utxo is from the payment address
   const filteredUnspentOutputs = unspentOutputs.filter((unspentOutput) => {
-    return !(
-      unspentOutput.txid === ordinalUtxo.txid && unspentOutput.vout === ordinalUtxo.vout
-    );
+    return !(unspentOutput.txid === ordinalUtxo.txid && unspentOutput.vout === ordinalUtxo.vout);
   });
 
   let ordinalUtxoInPaymentAddress = false;
@@ -723,7 +734,11 @@ export async function signOrdinalSendTransaction(
   // Calculate transaction fee
   let calculatedFee: BigNumber = new BigNumber(0);
   if (!fee) {
-    const { newSelectedUnspentOutputs, fee: modifiedFee, selectedFeeRate } = await getFee(
+    const {
+      newSelectedUnspentOutputs,
+      fee: modifiedFee,
+      selectedFeeRate,
+    } = await getFee(
       filteredUnspentOutputs,
       selectedUnspentOutputs,
       sumSelectedOutputs,


### PR DESCRIPTION
The fee would be different every time we fetch unspent outputs and calculate the fee from TX size.

I have added the sorting of unspent outputs before selecting for a transaction, on the basis of block time. This fixes the inconsistent fee issue. 

The unit tests are updated with correct mocking data. 

```
// Sort UTXOs based on block time in ascending order
  unspentOutputs.sort((a, b) => {
    if (a.status.block_time && b.status.block_time) {
      return a.status.block_time - b.status.block_time;
    }
    // Handle cases where block time is missing
    return 0;
  });
```