### PR TITLE
filter ordinal utxos to consider output index

### DIFF
--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -651,7 +651,7 @@ export async function signBtcTransaction(
 
   function filterUtxos(allUtxos: UTXO[], filterUtxoSet: UTXO[]) {
     return allUtxos.filter(
-      (utxo) => !filterUtxoSet.some((filterUtxo) => utxo.txid === filterUtxo.txid)
+      (utxo) => !filterUtxoSet.some((filterUtxo) => utxo.txid === filterUtxo.txid && utxo.vout === filterUtxo.vout)
     );
   }
 


### PR DESCRIPTION
in this previously merged PR https://github.com/secretkeylabs/xverse-core/pull/159 we added a change to the `signOrdinalSendTransaction` function to filter out all the `utxos` that includes ordinals that aren't being sent in the transaction.

the previous implementation relies on the `txid` when filtering the `utxos` which adds an edge-case where if you had another output in the same `tx` where an output that contains an ordinal is it was being filtered out

this change takes into account the output index when comparing utxos