### PR TITLE
Allow multiple btc recipients in ledger

### DIFF
--- a/ledger/index.ts
+++ b/ledger/index.ts
@@ -89,7 +89,7 @@ export async function signLedgerNativeSegwitBtcTransaction(
   transport: Transport,
   network: NetworkType,
   addressIndex: number,
-  recipient: Recipient
+  recipient: Array<Recipient>
 ): Promise<string> {
   const coinType = network === 'Mainnet' ? 0 : 1;
   const app = new AppClient(transport);
@@ -150,7 +150,7 @@ export async function signLedgerTaprootBtcTransaction(
   transport: Transport,
   network: NetworkType,
   addressIndex: number,
-  recipient: Recipient,
+  recipient: Array<Recipient>,
   btcAddress: string,
   ordinalUtxo?: UTXO
 ): Promise<string> {

--- a/ledger/index.ts
+++ b/ledger/index.ts
@@ -94,7 +94,7 @@ export async function signLedgerNativeSegwitBtcTransaction(
   transport: Transport,
   network: NetworkType,
   addressIndex: number,
-  recipient: Recipient,
+  recipients: Array<Recipient>,
   ): Promise<string> {
   const coinType = network === 'Mainnet' ? 0 : 1;
   const app = new AppClient(transport);
@@ -116,7 +116,7 @@ export async function signLedgerNativeSegwitBtcTransaction(
   const { selectedUTXOs, changeValue } = await getTransactionData(
     network,
     senderAddress,
-    recipient,
+    recipients,
   );
 
   const inputDerivation: Bip32Derivation = {
@@ -127,7 +127,7 @@ export async function signLedgerNativeSegwitBtcTransaction(
 
   const psbt = await createNativeSegwitPsbt(
     network,
-    recipient,
+    recipients,
     senderAddress,
     changeValue,
     selectedUTXOs,
@@ -155,7 +155,7 @@ export async function signLedgerTaprootBtcTransaction(
   transport: Transport,
   network: NetworkType,
   addressIndex: number,
-  recipient: Array<Recipient>,
+  recipients: Array<Recipient>,
   btcAddress: string,
   ordinalUtxo?: UTXO
   ): Promise<string> {
@@ -179,7 +179,7 @@ export async function signLedgerTaprootBtcTransaction(
   const { selectedUTXOs, changeValue } = await getTransactionData(
     network,
     btcAddress,
-    recipient,
+    recipients,
     ordinalUtxo
   );
 
@@ -192,7 +192,7 @@ export async function signLedgerTaprootBtcTransaction(
   };
   const psbt = await createTaprootPsbt(
     network,
-    recipient,
+    recipients,
     senderAddress,
     changeValue,
     selectedUTXOs,
@@ -222,7 +222,7 @@ export async function* signLedgerMixedBtcTransaction(
   transport: Transport,
   network: NetworkType,
   addressIndex: number,
-  recipient: Recipient,
+  recipients: Array<Recipient>,
   ordinalUtxo?: UTXO
   ): AsyncGenerator<string> {
   const coinType = network === 'Mainnet' ? 0 : 1;
@@ -245,7 +245,7 @@ export async function* signLedgerMixedBtcTransaction(
   const { selectedUTXOs, changeValue, ordinalUtxoInPaymentAddress } = await getTransactionData(
     network,
     senderAddress,
-    recipient,
+    recipients,
     ordinalUtxo
   );
 
@@ -276,7 +276,7 @@ export async function* signLedgerMixedBtcTransaction(
   // If the ordinal UTXO is in the payment address, we need to create a native segwit PSBT
   const psbt = ordinalUtxoInPaymentAddress ? await createNativeSegwitPsbt(
     network,
-    recipient,
+    recipients,
     senderAddress,
     changeValue,
     selectedUTXOs,
@@ -284,7 +284,7 @@ export async function* signLedgerMixedBtcTransaction(
     witnessScript,
   ) : await createMixedPsbt(
     network,
-    recipient,
+    recipients,
     senderAddress,
     changeValue,
     selectedUTXOs,


### PR DESCRIPTION
The current implementation of BTC transaction functions in ledger did not support multiple recipients. 
The PR updates the ledger functions so a BTC transaction with more than one recipient can be sent 


I tried broadcasting a multiple recipient transaction with ledger for testing with the given code: 
https://mempool.space/tx/36c17ce49bc6ec2b09757276c11fb83241d1fd2756e4e42040aced2631db6799