### PR TITLE
Filter utxos in send ordinal get fee function

### DIFF
--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -248,6 +248,17 @@ describe('bitcoin transactions', () => {
         },
         value: ordinalValue,
       },
+      {
+        status: {
+          block_hash: '00000000000000000003e6c56ae100b34fcc2967bc1deb53de1a4b9c29ba448f',
+          block_height: 797404,
+          block_time: 1688626274,
+          confirmed: true,
+        },
+        txid: 'd0dfe638a5be4f220f6435616edb5909a2f93540a7d6975ed0bdf305fb8bf51c',
+        value: 1347,
+        vout: 0,
+      },
     ];
 
     const utxos: Array<UTXO> = [
@@ -262,6 +273,7 @@ describe('bitcoin transactions', () => {
         },
         value: unspent1Value,
       },
+      ...ordinalOutputs,
     ];
 
     const fetchFeeRateSpy = vi.spyOn(XverseAPIFunctions, 'fetchBtcFeeRate');
@@ -279,8 +291,6 @@ describe('bitcoin transactions', () => {
 
     const ordinalUtxos = [
       {
-        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
-        blockHeight: 797404,
         status: {
           block_hash: '00000000000000000003e6c56ae100b34fcc2967bc1deb53de1a4b9c29ba448f',
           block_height: 797404,

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -277,7 +277,9 @@ describe('bitcoin transactions', () => {
     const ordinalAddress = 'bc1prtztqsgks2l6yuuhgsp36lw5n6dzpkj287lesqnfgktzqajendzq3p9urw';
     const btcAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
-    const { fee } = await getBtcFeesForOrdinalSend(recipientAddress, ordinalOutputs[0], btcAddress, network);
+    const { fee } = await getBtcFeesForOrdinalSend(recipientAddress, ordinalOutputs[0], btcAddress, network, [
+      ordinalOutputs[0],
+    ]);
 
     // expect transaction size to be 260 bytes;
     const txSize = 260;

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -277,9 +277,29 @@ describe('bitcoin transactions', () => {
     const ordinalAddress = 'bc1prtztqsgks2l6yuuhgsp36lw5n6dzpkj287lesqnfgktzqajendzq3p9urw';
     const btcAddress = '1H8voHF7NNoyz76h9s6dZSeoypJQamX4xT';
 
-    const { fee } = await getBtcFeesForOrdinalSend(recipientAddress, ordinalOutputs[0], btcAddress, network, [
+    const ordinalUtxos = [
+      {
+        address: '3BMxVoc3NVt8BHakAh28WZrpQqQKCxV28U',
+        blockHeight: 797404,
+        status: {
+          block_hash: '00000000000000000003e6c56ae100b34fcc2967bc1deb53de1a4b9c29ba448f',
+          block_height: 797404,
+          block_time: 1688626274,
+          confirmed: true,
+        },
+        txid: 'd0dfe638a5be4f220f6435616edb5909a2f93540a7d6975ed0bdf305fb8bf51c',
+        value: 1347,
+        vout: 0,
+      },
+    ];
+
+    const { fee } = await getBtcFeesForOrdinalSend(
+      recipientAddress,
       ordinalOutputs[0],
-    ]);
+      btcAddress,
+      network,
+      ordinalUtxos,
+    );
 
     // expect transaction size to be 260 bytes;
     const txSize = 260;

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -774,7 +774,7 @@ export async function signOrdinalSendTransaction(
     total: satsToSend,
   };
 
-  return await Promise.resolve(signedBtcTx);
+  return signedBtcTx;
 }
 
 export async function signNonOrdinalBtcSendTransaction(


### PR DESCRIPTION
- added the filterutxos in the fee calculation for ordinal send to make sure ordinal UTXO is removed from UTXO set used for fees. 
- added a try-catch block in `signOrdinalSendTransaction` to catch and reject the promise. 
- updated test for `getBtcFeesForOrdinalSend` function

Change on apps: 
 - we need to pass in an additional parameter addressOrdinalsUtxos added in `getBtcFeesForOrdinalSend` same as `signOrdinalSendTransaction`