### PR TITLE
chore: use proper stacks.gamma.io host

### DIFF
--- a/constant.ts
+++ b/constant.ts
@@ -30,7 +30,7 @@ export const BLOCKCYPHER_BASE_URI_MAINNET = 'https://api.blockcypher.com/v1/btc/
 
 export const BLOCKCYPHER_BASE_URI_TESTNET = 'https://api.blockcypher.com/v1/btc/test3';
 
-export const NFT_BASE_URI = 'https://gamma.io/api/v1/collections';
+export const NFT_BASE_URI = 'https://stacks.gamma.io/api/v1/collections';
 
 export const XVERSE_API_BASE_URL = 'https://api.xverse.app';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",


### PR DESCRIPTION
before change:

making 2 requests for each NFT (redirected from gamma.io -> stacks.gamma.io)
![Screenshot 2023-07-05 at 3 31 32 PM](https://github.com/secretkeylabs/xverse-core/assets/6109710/9ef17e7d-69df-4e57-a5db-65dce5c1906f)

after change:

making 1 request for each NFT to stacks.gamma.io
![image](https://github.com/secretkeylabs/xverse-core/assets/6109710/41016ebb-6895-41d4-a97f-9e00d6eae1c5)

