### PR TITLE
Add the sponsored param back to stx transaction type

### DIFF
--- a/transactions/stx.ts
+++ b/transactions/stx.ts
@@ -143,7 +143,7 @@ export async function generateUnsignedSTXTokenTransfer(
     memo: memo ?? '',
     network: txNetwork,
     fee: 0,
-    sponsored: sponsored,
+    sponsored,
     anchorMode: anchorMode ? anchorMode : AnchorMode.Any,
     postConditionMode,
     postConditions,
@@ -280,7 +280,7 @@ export async function estimateContractCallFees(
 export async function generateUnsignedTransaction(
   unsginedTx: UnsignedStacksTransation
 ): Promise<StacksTransaction> {
-  var unsignedTx;
+  let unsignedTx;
   const functionName = 'transfer';
   let functionArgs: ClarityValue[];
 
@@ -296,6 +296,7 @@ export async function generateUnsignedTransaction(
     publicKey,
     network,
     pendingTxs,
+    sponsored,
   } = unsginedTx;
 
   const postConditionOptions: PostConditionsOptions = {
@@ -338,6 +339,7 @@ export async function generateUnsignedTransaction(
       network,
       nonce: undefined,
       postConditions: postConditions,
+      sponsored,
     };
     unsignedTx = await generateUnsignedContractCall(unsignedContractCallParam);
 

--- a/types/api/stacks/transaction.ts
+++ b/types/api/stacks/transaction.ts
@@ -27,6 +27,7 @@ export type UnsignedStacksTransation = {
   pendingTxs: StxMempoolTransactionData[];
   memo?: string;
   isNFT?: boolean;
+  sponsored?: boolean;
 };
 
 export type UnsignedContractCallTransaction = {


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
The `UnsignedStacksTransation` type did not have a `sponsored` param which is needed for creating sponsored transactions.

Related fix on app for sponsored transactions:
https://github.com/secretkeylabs/xverse/pull/1136


# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
Added optional `sponsored` param to `UnsignedStacksTransation` type

Impact:
Fixes type error when building sponsored transactions.

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
