### PR TITLE
fix: don't run publish beta on fork PR

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
       is-not-fork: ${{ steps.check.outputs.is_not_fork }}
     steps:
       - id: check
-        run: echo "::set-output name=is_not_fork::${{ github.repository == 'secretkeylabs/xverse-core' }}"
+        run: echo "::set-output name=is_not_fork::${{ github.event.pull_request.head.repo.full_name == github.repository }}"
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
We publish a beta package for testing Xverse-core PRs. Since fork PRs run in the context of the forked repo for security reasons, we cannot do this publish for forks. This fixes the fork check to disable the publish for fork PRs.

The previous behaviour would check if the target was our repo, so all it was doing was preventing the run on PRs of forks into any forked target. This one specifically prevents runs on PRs between repos.

Context Link (if applicable): ENG-2447

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [X] No, Bug fixes (backwards compatible)

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
