### PR TITLE
feat: implement required calls to inscribe service for BRC20 transfer

### DIFF
--- a/api/xverseInscribe.ts
+++ b/api/xverseInscribe.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+
+import {
+  Brc20CostEstimateRequest,
+  Brc20CostEstimateResponse,
+  Brc20CreateOrderRequest,
+  Brc20CreateOrderResponse,
+  Brc20ExecuteOrderRequest,
+  Brc20ExecuteOrderResponse,
+  NetworkType,
+} from 'types';
+
+import { XVERSE_INSCRIBE_URL } from '../constant';
+
+const apiClient = axios.create({
+  baseURL: XVERSE_INSCRIBE_URL,
+});
+
+const getBrc20TransferFees = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+): Promise<Brc20CostEstimateResponse> => {
+  const requestBody: Brc20CostEstimateRequest = {
+    operation: 'transfer',
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+  };
+  const response = await apiClient.post<Brc20CostEstimateResponse>('/v1/brc20/cost-estimate', requestBody);
+  return response.data;
+};
+
+const createBrc20TransferOrder = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+  network: NetworkType,
+): Promise<Brc20CreateOrderResponse> => {
+  const requestBody: Brc20CreateOrderRequest = {
+    operation: 'transfer',
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+    network,
+  };
+  const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/cost-estimate', requestBody);
+  return response.data;
+};
+
+const executeBrc20TransferOrder = async (
+  commitAddress: string,
+  commitTransactionHex: string,
+): Promise<Brc20ExecuteOrderResponse> => {
+  const requestBody: Brc20ExecuteOrderRequest = {
+    commitAddress,
+    commitTransactionHex,
+  };
+  const response = await apiClient.post<Brc20ExecuteOrderResponse>('/v1/brc20/cost-estimate', requestBody);
+  return response.data;
+};
+
+export default {
+  getBrc20TransferFees,
+  createBrc20TransferOrder,
+  executeBrc20TransferOrder,
+};

--- a/api/xverseInscribe.ts
+++ b/api/xverseInscribe.ts
@@ -7,6 +7,8 @@ import {
   Brc20CreateOrderResponse,
   Brc20ExecuteOrderRequest,
   Brc20ExecuteOrderResponse,
+  Brc20FinalizeTransferOrderRequest,
+  Brc20FinalizeTransferOrderResponse,
   NetworkType,
 } from 'types';
 
@@ -143,12 +145,26 @@ const createBrc20DeployOrder = async (
 const executeBrc20Order = async (
   commitAddress: string,
   commitTransactionHex: string,
+  skipFinalize?: boolean,
 ): Promise<Brc20ExecuteOrderResponse> => {
   const requestBody: Brc20ExecuteOrderRequest = {
     commitAddress,
     commitTransactionHex,
+    skipFinalize,
   };
   const response = await apiClient.post<Brc20ExecuteOrderResponse>('/v1/brc20/execute-order', requestBody);
+  return response.data;
+};
+
+const finalizeBrc20TransferOrder = async (
+  commitAddress: string,
+  transferTransactionHex: string,
+): Promise<Brc20FinalizeTransferOrderResponse> => {
+  const requestBody: Brc20FinalizeTransferOrderRequest = {
+    commitAddress,
+    transferTransactionHex,
+  };
+  const response = await apiClient.post<Brc20FinalizeTransferOrderResponse>('/v1/brc20/finalize-order', requestBody);
   return response.data;
 };
 
@@ -160,4 +176,5 @@ export default {
   getBrc20DeployFees,
   createBrc20DeployOrder,
   executeBrc20Order,
+  finalizeBrc20TransferOrder,
 };

--- a/api/xverseInscribe.ts
+++ b/api/xverseInscribe.ts
@@ -21,6 +21,7 @@ const getBrc20TransferFees = async (
   amount: number,
   revealAddress: string,
   feeRate: number,
+  inscriptionValue?: number,
 ): Promise<Brc20CostEstimateResponse> => {
   const requestBody: Brc20CostEstimateRequest = {
     operation: 'transfer',
@@ -28,6 +29,7 @@ const getBrc20TransferFees = async (
     amount,
     revealAddress,
     feeRate,
+    inscriptionValue,
   };
   const response = await apiClient.post<Brc20CostEstimateResponse>('/v1/brc20/cost-estimate', requestBody);
   return response.data;
@@ -39,6 +41,7 @@ const createBrc20TransferOrder = async (
   revealAddress: string,
   feeRate: number,
   network: NetworkType,
+  inscriptionValue?: number,
 ): Promise<Brc20CreateOrderResponse> => {
   const requestBody: Brc20CreateOrderRequest = {
     operation: 'transfer',
@@ -47,6 +50,7 @@ const createBrc20TransferOrder = async (
     revealAddress,
     feeRate,
     network,
+    inscriptionValue,
   };
   const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/cost-estimate', requestBody);
   return response.data;

--- a/api/xverseInscribe.ts
+++ b/api/xverseInscribe.ts
@@ -52,11 +52,95 @@ const createBrc20TransferOrder = async (
     network,
     inscriptionValue,
   };
-  const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/cost-estimate', requestBody);
+  const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/place-order', requestBody);
   return response.data;
 };
 
-const executeBrc20TransferOrder = async (
+const getBrc20MintFees = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+  inscriptionValue?: number,
+): Promise<Brc20CostEstimateResponse> => {
+  const requestBody: Brc20CostEstimateRequest = {
+    operation: 'mint',
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+    inscriptionValue,
+  };
+  const response = await apiClient.post<Brc20CostEstimateResponse>('/v1/brc20/cost-estimate', requestBody);
+  return response.data;
+};
+
+const createBrc20MintOrder = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+  network: NetworkType,
+  inscriptionValue?: number,
+): Promise<Brc20CreateOrderResponse> => {
+  const requestBody: Brc20CreateOrderRequest = {
+    operation: 'mint',
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+    network,
+    inscriptionValue,
+  };
+  const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/place-order', requestBody);
+  return response.data;
+};
+
+const getBrc20DeployFees = async (
+  tick: string,
+  max: number,
+  limit: number,
+  revealAddress: string,
+  feeRate: number,
+  inscriptionValue?: number,
+): Promise<Brc20CostEstimateResponse> => {
+  const requestBody: Brc20CostEstimateRequest = {
+    operation: 'deploy',
+    tick,
+    lim: limit,
+    max: max,
+    revealAddress,
+    feeRate,
+    inscriptionValue,
+  };
+  const response = await apiClient.post<Brc20CostEstimateResponse>('/v1/brc20/cost-estimate', requestBody);
+  return response.data;
+};
+
+const createBrc20DeployOrder = async (
+  tick: string,
+  max: number,
+  limit: number,
+  revealAddress: string,
+  feeRate: number,
+  network: NetworkType,
+  inscriptionValue?: number,
+): Promise<Brc20CreateOrderResponse> => {
+  const requestBody: Brc20CreateOrderRequest = {
+    operation: 'deploy',
+    tick,
+    lim: limit,
+    max: max,
+    revealAddress,
+    feeRate,
+    network,
+    inscriptionValue,
+  };
+  const response = await apiClient.post<Brc20CreateOrderResponse>('/v1/brc20/place-order', requestBody);
+  return response.data;
+};
+
+const executeBrc20Order = async (
   commitAddress: string,
   commitTransactionHex: string,
 ): Promise<Brc20ExecuteOrderResponse> => {
@@ -64,12 +148,16 @@ const executeBrc20TransferOrder = async (
     commitAddress,
     commitTransactionHex,
   };
-  const response = await apiClient.post<Brc20ExecuteOrderResponse>('/v1/brc20/cost-estimate', requestBody);
+  const response = await apiClient.post<Brc20ExecuteOrderResponse>('/v1/brc20/execute-order', requestBody);
   return response.data;
 };
 
 export default {
   getBrc20TransferFees,
   createBrc20TransferOrder,
-  executeBrc20TransferOrder,
+  getBrc20MintFees,
+  createBrc20MintOrder,
+  getBrc20DeployFees,
+  createBrc20DeployOrder,
+  executeBrc20Order,
 };

--- a/constant.ts
+++ b/constant.ts
@@ -34,6 +34,8 @@ export const NFT_BASE_URI = 'https://stacks.gamma.io/api/v1/collections';
 
 export const XVERSE_API_BASE_URL = 'https://api.xverse.app';
 
+export const XVERSE_INSCRIBE_URL = 'https://inscribe.xverse.app';
+
 export const XVERSE_SPONSOR_URL = 'https://sponsor.xverse.app';
 
 export const GAIA_HUB_URL = 'https://hub.blockstack.org';
@@ -42,52 +44,52 @@ export const HIRO_MAINNET_DEFAULT = 'https://api.hiro.so';
 
 export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';
 
-export const  supportedCoins =  [
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token",
-        "name": "ALEX"
-    },
-    {
-        "contract": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token",
-        "name": "Arkadiko Token"
-    },
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.auto-alex",
-        "name": "Auto ALEX"
-    },
-    {
-        "contract": "SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2",
-        "name": "MiamiCoin"
-    },
-    {
-        "contract": "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2",
-        "name": "NewYorkCityCoin"
-    },
-    {
-        "contract": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token",
-        "name": "USDA"
-    },
-    {
-        "contract": "SP27BB1Y2DGSXZHS7G9YHKTSH6KQ6BD3QG0AN3CR9.vibes-token",
-        "name": "Vibes"
-    },
-    {
-        "contract": "SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin",
-        "name": "Wrapped Bitcoin"
-    },
-    {
-        "contract": "SP2TZK01NKDC89J6TA56SA47SDF7RTHYEQ79AAB9A.Wrapped-USD",
-        "name": "Wrapped USD"
-    },
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt",
-        "name": "Wrapped USDT"
-    },
-    {
-        "contract": "SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.slime-token",
-        "name": "SLIME"
-    }
-]
+export const supportedCoins = [
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token',
+    name: 'ALEX',
+  },
+  {
+    contract: 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token',
+    name: 'Arkadiko Token',
+  },
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.auto-alex',
+    name: 'Auto ALEX',
+  },
+  {
+    contract: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2',
+    name: 'MiamiCoin',
+  },
+  {
+    contract: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2',
+    name: 'NewYorkCityCoin',
+  },
+  {
+    contract: 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token',
+    name: 'USDA',
+  },
+  {
+    contract: 'SP27BB1Y2DGSXZHS7G9YHKTSH6KQ6BD3QG0AN3CR9.vibes-token',
+    name: 'Vibes',
+  },
+  {
+    contract: 'SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin',
+    name: 'Wrapped Bitcoin',
+  },
+  {
+    contract: 'SP2TZK01NKDC89J6TA56SA47SDF7RTHYEQ79AAB9A.Wrapped-USD',
+    name: 'Wrapped USD',
+  },
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt',
+    name: 'Wrapped USDT',
+  },
+  {
+    contract: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.slime-token',
+    name: 'SLIME',
+  },
+];
 export const ORDINALS_URL = (inscriptionId: string) =>
   `https://api.hiro.so/ordinals/v1/inscriptions/${inscriptionId}/content`;
 

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UTXO } from 'types';
+import BitcoinEsploraApiProvider from '../../api/esplora/esploraAPiProvider';
+import xverseInscribeApi from '../../api/xverseInscribe';
+import {
+  generateSignedBtcTransaction,
+  selectUtxosForSend,
+  signNonOrdinalBtcSendTransaction,
+} from '../../transactions/btc';
+import { getBtcPrivateKey } from '../../wallet';
+
+import BigNumber from 'bignumber.js';
+import {
+  brc20TransferEstimateFees,
+  brc20TransferExecute,
+  ExecuteTransferProgressCodes,
+} from '../../transactions/brc20';
+
+vi.mock('../../api/xverseInscribe');
+vi.mock('../../api/esplora/esploraAPiProvider');
+vi.mock('../../transactions/btc');
+vi.mock('../../wallet');
+
+describe('brc20TransferEstimateFees', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should estimate BRC20 transfer fees correctly', async () => {
+    // Mock the dependencies or external modules if necessary
+    const mockedAddressUtxos: UTXO[] = [];
+    const mockedTick = 'TICK';
+    const mockedAmount = 10;
+    const mockedRevealAddress = 'bc1pyzfhlkq29sylwlv72ve52w8mn7hclefzhyay3dxh32r0322yx6uqajvr3y';
+    const mockedFeeRate = 12;
+
+    vi.mocked(signNonOrdinalBtcSendTransaction).mockResolvedValueOnce({
+      tx: { vsize: 150 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we only use this field in this function
+    } as any);
+
+    vi.mocked(xverseInscribeApi.getBrc20TransferFees).mockResolvedValue({
+      chainFee: 1080,
+      serviceFee: 2000,
+      inscriptionValue: 1000,
+      vSize: 150,
+    });
+
+    vi.mocked(selectUtxosForSend).mockReturnValueOnce({
+      change: 2070,
+      fee: 1070,
+      feeRate: 12,
+      selectedUtxos: [],
+    });
+
+    const result = await brc20TransferEstimateFees(
+      mockedAddressUtxos,
+      mockedTick,
+      mockedAmount,
+      mockedRevealAddress,
+      mockedFeeRate,
+    );
+
+    expect(result).toEqual({
+      commitValue: 1070 + 1080 + 2000 + 1800 + 1000,
+      valueBreakdown: {
+        commitChainFee: 1070,
+        revealChainFee: 1080,
+        revealServiceFee: 2000,
+        transferChainFee: 1800,
+        transferUtxoValue: 1000,
+      },
+    });
+
+    expect(xverseInscribeApi.getBrc20TransferFees).toHaveBeenCalledWith(
+      mockedTick,
+      mockedAmount,
+      mockedRevealAddress,
+      mockedFeeRate,
+      2800,
+    );
+
+    expect(selectUtxosForSend).toHaveBeenCalledWith(
+      'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh',
+      [{ address: mockedRevealAddress, amountSats: new BigNumber(5880) }],
+      mockedAddressUtxos,
+      mockedFeeRate,
+    );
+  });
+});
+
+describe('brc20TransferExecute', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should execute BRC20 transfer correctly', async () => {
+    // Mock the dependencies or external modules if necessary
+    const mockedSeedPhrase = 'seed_phrase';
+    const mockedAccountIndex = 0;
+    const mockedAddressUtxos: UTXO[] = [];
+    const mockedTick = 'TICK';
+    const mockedAmount = 10;
+    const mockedRevealAddress = 'reveal_address';
+    const mockedChangeAddress = 'change_address';
+    const mockedRecipientAddress = 'recipient_address';
+    const mockedFeeRate = 12;
+    const mockedNetwork = 'Mainnet';
+
+    vi.mocked(getBtcPrivateKey).mockResolvedValueOnce('private_key');
+
+    vi.mocked(signNonOrdinalBtcSendTransaction).mockResolvedValue({
+      tx: { vsize: 150 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we only use this field in this function
+    } as any);
+
+    vi.mocked(xverseInscribeApi.createBrc20TransferOrder).mockResolvedValueOnce({
+      commitAddress: 'commit_address',
+      commitValue: 1000,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we only use these 2 fields in this function
+    } as any);
+
+    const mockedSelectedUtxos: UTXO[] = [];
+    vi.mocked(selectUtxosForSend).mockReturnValueOnce({
+      change: 2070,
+      fee: 1070,
+      feeRate: mockedFeeRate,
+      selectedUtxos: mockedSelectedUtxos,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- only use the one field in this method
+    vi.mocked(generateSignedBtcTransaction).mockResolvedValueOnce({ hex: 'commit_hex' } as any);
+
+    vi.mocked(xverseInscribeApi.executeBrc20Order).mockResolvedValueOnce({
+      revealTransactionId: 'revealId',
+      revealUTXOVOut: 0,
+      revealUTXOValue: 3000,
+    });
+
+    vi.mocked(BitcoinEsploraApiProvider).mockImplementation(
+      () =>
+        ({
+          sendRawTransaction: vi.fn().mockResolvedValueOnce({ tx: { hash: 'tx_hash' } }),
+        } as any),
+    );
+
+    // Execute the generator function
+    const generator = brc20TransferExecute(
+      mockedSeedPhrase,
+      mockedAccountIndex,
+      mockedAddressUtxos,
+      mockedTick,
+      mockedAmount,
+      mockedRevealAddress,
+      mockedChangeAddress,
+      mockedRecipientAddress,
+      mockedFeeRate,
+      mockedNetwork,
+    );
+
+    let result;
+    let done;
+
+    // Iterate through the generator function until it's done
+    do {
+      ({ value: result, done } = await generator.next());
+
+      // Assert the progress and result based on the current value
+      switch (result) {
+        case ExecuteTransferProgressCodes.CreatingInscriptionOrder:
+          expect(getBtcPrivateKey).toHaveBeenCalledWith(
+            expect.objectContaining({
+              seedPhrase: mockedSeedPhrase,
+              index: BigInt(mockedAccountIndex),
+              network: 'Mainnet',
+            }),
+          );
+          break;
+
+        case ExecuteTransferProgressCodes.CreatingCommitTransaction:
+          expect(signNonOrdinalBtcSendTransaction).toHaveBeenCalledTimes(1);
+          expect(signNonOrdinalBtcSendTransaction).toHaveBeenCalledWith(
+            mockedRecipientAddress,
+            [
+              {
+                address: mockedRevealAddress,
+                status: { confirmed: false },
+                txid: '0000000000000000000000000000000000000000000000000000000000000001',
+                vout: 0,
+                value: 1000,
+              },
+            ],
+            0,
+            mockedSeedPhrase,
+            'Mainnet',
+          );
+
+          expect(xverseInscribeApi.createBrc20TransferOrder).toHaveBeenCalledWith(
+            mockedTick,
+            mockedAmount,
+            mockedRevealAddress,
+            mockedFeeRate,
+            'Mainnet',
+            1000 + 150 * mockedFeeRate,
+          );
+          break;
+
+        case ExecuteTransferProgressCodes.ExecutingInscriptionOrder:
+          expect(selectUtxosForSend).toHaveBeenCalledWith(
+            mockedChangeAddress,
+            [{ address: mockedRevealAddress, amountSats: new BigNumber(1000) }],
+            mockedAddressUtxos,
+            mockedFeeRate,
+          );
+
+          expect(generateSignedBtcTransaction).toHaveBeenCalledWith(
+            'private_key',
+            mockedSelectedUtxos,
+            new BigNumber(1000),
+            [
+              {
+                address: 'commit_address',
+                amountSats: new BigNumber(1000),
+              },
+            ],
+            mockedChangeAddress,
+            new BigNumber(1070),
+            'Mainnet',
+          );
+          break;
+
+        case ExecuteTransferProgressCodes.CreatingTransferTransaction:
+          expect(xverseInscribeApi.executeBrc20Order).toHaveBeenCalledWith('commit_address', 'commit_hex');
+          break;
+
+        case ExecuteTransferProgressCodes.Finalizing:
+          expect(signNonOrdinalBtcSendTransaction).toHaveBeenCalledTimes(2);
+          expect(signNonOrdinalBtcSendTransaction).toHaveBeenLastCalledWith(
+            mockedRecipientAddress,
+            [
+              {
+                address: mockedRevealAddress,
+                status: { confirmed: false },
+                txid: 'revealId',
+                vout: 0,
+                value: 3000,
+              },
+            ],
+            0,
+            mockedSeedPhrase,
+            'Mainnet',
+            new BigNumber(1800),
+          );
+
+          break;
+        default:
+          break;
+      }
+    } while (!done);
+
+    expect(result).toEqual('tx_hash');
+  });
+});

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -351,6 +351,7 @@ describe('brc20TransferExecute', () => {
             0,
             mockedSeedPhrase,
             'Mainnet',
+            new BigNumber(1),
           );
 
           expect(xverseInscribeApi.createBrc20TransferOrder).toHaveBeenCalledWith(

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -50,13 +50,13 @@ describe('brc20MintEstimateFees', () => {
       selectedUtxos: [],
     });
 
-    const result = await brc20MintEstimateFees(
-      mockedAddressUtxos,
-      mockedTick,
-      mockedAmount,
-      mockedRevealAddress,
-      mockedFeeRate,
-    );
+    const result = await brc20MintEstimateFees({
+      addressUtxos: mockedAddressUtxos,
+      tick: mockedTick,
+      amount: mockedAmount,
+      revealAddress: mockedRevealAddress,
+      feeRate: mockedFeeRate,
+    });
 
     expect(result).toEqual({
       commitValue: 1070 + 1080 + 2000 + 1000,
@@ -124,17 +124,17 @@ describe('brc20MintExecute', () => {
       revealUTXOValue: 3000,
     });
 
-    const result = await brc20MintExecute(
-      mockedSeedPhrase,
-      mockedAccountIndex,
-      mockedAddressUtxos,
-      mockedTick,
-      mockedAmount,
-      mockedRevealAddress,
-      mockedChangeAddress,
-      mockedFeeRate,
-      mockedNetwork,
-    );
+    const result = await brc20MintExecute({
+      seedPhrase: mockedSeedPhrase,
+      accountIndex: mockedAccountIndex,
+      addressUtxos: mockedAddressUtxos,
+      tick: mockedTick,
+      amount: mockedAmount,
+      revealAddress: mockedRevealAddress,
+      changeAddress: mockedChangeAddress,
+      feeRate: mockedFeeRate,
+      network: mockedNetwork,
+    });
 
     expect(result).toEqual('revealId');
 
@@ -212,13 +212,13 @@ describe('brc20TransferEstimateFees', () => {
       selectedUtxos: [],
     });
 
-    const result = await brc20TransferEstimateFees(
-      mockedAddressUtxos,
-      mockedTick,
-      mockedAmount,
-      mockedRevealAddress,
-      mockedFeeRate,
-    );
+    const result = await brc20TransferEstimateFees({
+      addressUtxos: mockedAddressUtxos,
+      tick: mockedTick,
+      amount: mockedAmount,
+      revealAddress: mockedRevealAddress,
+      feeRate: mockedFeeRate,
+    });
 
     expect(result).toEqual({
       commitValue: 1070 + 1080 + 2000 + 1800 + 1000,
@@ -303,18 +303,18 @@ describe('brc20TransferExecute', () => {
     );
 
     // Execute the generator function
-    const generator = brc20TransferExecute(
-      mockedSeedPhrase,
-      mockedAccountIndex,
-      mockedAddressUtxos,
-      mockedTick,
-      mockedAmount,
-      mockedRevealAddress,
-      mockedChangeAddress,
-      mockedRecipientAddress,
-      mockedFeeRate,
-      mockedNetwork,
-    );
+    const generator = brc20TransferExecute({
+      seedPhrase: mockedSeedPhrase,
+      accountIndex: mockedAccountIndex,
+      addressUtxos: mockedAddressUtxos,
+      tick: mockedTick,
+      amount: mockedAmount,
+      revealAddress: mockedRevealAddress,
+      changeAddress: mockedChangeAddress,
+      recipientAddress: mockedRecipientAddress,
+      feeRate: mockedFeeRate,
+      network: mockedNetwork,
+    });
 
     let result;
     let done;

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -76,12 +76,12 @@ describe('brc20MintEstimateFees', () => {
       1000,
     );
 
-    expect(selectUtxosForSend).toHaveBeenCalledWith(
-      'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh',
-      [{ address: mockedRevealAddress, amountSats: new BigNumber(4080) }],
-      mockedAddressUtxos,
-      mockedFeeRate,
-    );
+    expect(selectUtxosForSend).toHaveBeenCalledWith({
+      changeAddress: 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh',
+      recipients: [{ address: mockedRevealAddress, amountSats: new BigNumber(4080) }],
+      availableUtxos: mockedAddressUtxos,
+      feeRate: mockedFeeRate,
+    });
   });
 });
 
@@ -155,12 +155,12 @@ describe('brc20MintExecute', () => {
       1000,
     );
 
-    expect(selectUtxosForSend).toHaveBeenCalledWith(
-      'change_address',
-      [{ address: mockedRevealAddress, amountSats: new BigNumber(1000) }],
-      mockedAddressUtxos,
-      mockedFeeRate,
-    );
+    expect(selectUtxosForSend).toHaveBeenCalledWith({
+      changeAddress: 'change_address',
+      recipients: [{ address: mockedRevealAddress, amountSats: new BigNumber(1000) }],
+      availableUtxos: mockedAddressUtxos,
+      feeRate: mockedFeeRate,
+    });
 
     expect(generateSignedBtcTransaction).toHaveBeenCalledWith(
       'private_key',
@@ -239,12 +239,12 @@ describe('brc20TransferEstimateFees', () => {
       2800,
     );
 
-    expect(selectUtxosForSend).toHaveBeenCalledWith(
-      'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh',
-      [{ address: mockedRevealAddress, amountSats: new BigNumber(5880) }],
-      mockedAddressUtxos,
-      mockedFeeRate,
-    );
+    expect(selectUtxosForSend).toHaveBeenCalledWith({
+      changeAddress: 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh',
+      recipients: [{ address: mockedRevealAddress, amountSats: new BigNumber(5880) }],
+      availableUtxos: mockedAddressUtxos,
+      feeRate: mockedFeeRate,
+    });
   });
 });
 
@@ -371,12 +371,12 @@ describe('brc20TransferExecute', () => {
           break;
 
         case ExecuteTransferProgressCodes.ExecutingInscriptionOrder:
-          expect(selectUtxosForSend).toHaveBeenCalledWith(
-            mockedChangeAddress,
-            [{ address: mockedRevealAddress, amountSats: new BigNumber(1000) }],
-            mockedAddressUtxos,
-            mockedFeeRate,
-          );
+          expect(selectUtxosForSend).toHaveBeenCalledWith({
+            changeAddress: mockedChangeAddress,
+            recipients: [{ address: mockedRevealAddress, amountSats: new BigNumber(1000) }],
+            availableUtxos: mockedAddressUtxos,
+            feeRate: mockedFeeRate,
+          });
 
           expect(generateSignedBtcTransaction).toHaveBeenCalledWith(
             'private_key',

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -302,6 +302,12 @@ describe('brc20TransferExecute', () => {
         } as any),
     );
 
+    vi.mocked(xverseInscribeApi.finalizeBrc20TransferOrder).mockResolvedValueOnce({
+      revealTransactionId: 'revealId',
+      commitTransactionId: 'commitId',
+      transferTransactionId: 'transferId',
+    });
+
     // Execute the generator function
     const generator = brc20TransferExecute({
       seedPhrase: mockedSeedPhrase,
@@ -389,7 +395,7 @@ describe('brc20TransferExecute', () => {
           break;
 
         case ExecuteTransferProgressCodes.CreatingTransferTransaction:
-          expect(xverseInscribeApi.executeBrc20Order).toHaveBeenCalledWith('commit_address', 'commit_hex');
+          expect(xverseInscribeApi.executeBrc20Order).toHaveBeenCalledWith('commit_address', 'commit_hex', true);
           break;
 
         case ExecuteTransferProgressCodes.Finalizing:
@@ -417,6 +423,10 @@ describe('brc20TransferExecute', () => {
       }
     } while (!done);
 
-    expect(result).toEqual('tx_hash');
+    expect(result).toEqual({
+      revealTransactionId: 'revealId',
+      commitTransactionId: 'commitId',
+      transferTransactionId: 'transferId',
+    });
   });
 });

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -7,6 +7,7 @@ import xverseInscribeApi from '../api/xverseInscribe';
 import { getBtcPrivateKey } from '../wallet';
 import { generateSignedBtcTransaction, selectUtxosForSend, signNonOrdinalBtcSendTransaction } from './btc';
 
+// This is the value of the inscription output, which the final recipient of the inscription will receive.
 const FINAL_SATS_VALUE = 1000;
 
 type EstimateProps = {
@@ -15,6 +16,28 @@ type EstimateProps = {
   amount: number;
   revealAddress: string;
   feeRate: number;
+};
+
+type BaseEstimateResult = {
+  commitValue: number;
+  valueBreakdown: {
+    commitChainFee: number;
+    revealChainFee: number;
+    revealServiceFee: number;
+  };
+};
+
+type EstimateResult = BaseEstimateResult & {
+  valueBreakdown: {
+    inscriptionValue: number;
+  };
+};
+
+type TransferEstimateResult = BaseEstimateResult & {
+  valueBreakdown: {
+    transferChainFee: number;
+    transferUtxoValue: number;
+  };
 };
 
 type ExecuteProps = {
@@ -61,7 +84,7 @@ export const createBrc20TransferOrder = async (token: string, amount: string, re
   };
 };
 
-export const brc20MintEstimateFees = async (estimateProps: EstimateProps) => {
+export const brc20MintEstimateFees = async (estimateProps: EstimateProps): Promise<EstimateResult> => {
   const { addressUtxos, tick, amount, revealAddress, feeRate } = estimateProps;
   const dummyAddress = 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh';
 
@@ -151,7 +174,7 @@ export async function brc20MintExecute(executeProps: ExecuteProps): Promise<stri
   return revealTransactionId;
 }
 
-export const brc20TransferEstimateFees = async (estimateProps: EstimateProps) => {
+export const brc20TransferEstimateFees = async (estimateProps: EstimateProps): Promise<TransferEstimateResult> => {
   const { addressUtxos, tick, amount, revealAddress, feeRate } = estimateProps;
 
   const dummyAddress = 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh';

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -247,5 +247,5 @@ export async function* brc20TransferExecute(
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
-  throw error!;
+  throw error ?? new Error('Failed to broadcast transfer transaction');
 }

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -172,6 +172,7 @@ export const brc20TransferEstimateFees = async (estimateProps: EstimateProps) =>
     0,
     'action action action action action action action action action action action action',
     'Mainnet',
+    new BigNumber(1),
   );
 
   const transferFeeEstimate = tx.vsize * feeRate;
@@ -264,6 +265,7 @@ export async function* brc20TransferExecute(
     accountIndex,
     seedPhrase,
     'Mainnet',
+    new BigNumber(1),
   );
 
   const transferFeeEstimate = tx.vsize * feeRate;

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -1,27 +1,24 @@
 import { base64 } from '@scure/base';
+import { NetworkType } from 'types';
 import { createInscriptionRequest } from '../api';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import xverseInscribeApi from '../api/xverseInscribe';
 
-const createTransferInscriptionContent = (token: string, amount: string) =>
-  ({
-    p: 'brc-20',
-    op: 'transfer',
-    tick: token,
-    amt: amount,
-  });
+const createTransferInscriptionContent = (token: string, amount: string) => ({
+  p: 'brc-20',
+  op: 'transfer',
+  tick: token,
+  amt: amount,
+});
 
 const btcClient = new BitcoinEsploraApiProvider({
-    network: 'Mainnet',
-})
+  network: 'Mainnet',
+});
 
-export const createBrc20TransferOrder = async (
-  token: string,
-  amount: string,
-  recipientAddress: string,
-) => {
+export const createBrc20TransferOrder = async (token: string, amount: string, recipientAddress: string) => {
   const transferInscriptionContent = createTransferInscriptionContent(token, amount);
   const contentB64 = base64.encode(Buffer.from(JSON.stringify(transferInscriptionContent)));
-  const contentSize = Buffer.from(JSON.stringify(transferInscriptionContent)).length
+  const contentSize = Buffer.from(JSON.stringify(transferInscriptionContent)).length;
   const feesResponse = await btcClient.getRecommendedFees();
   const inscriptionRequest = await createInscriptionRequest(
     recipientAddress,
@@ -36,4 +33,44 @@ export const createBrc20TransferOrder = async (
     inscriptionRequest,
     feesResponse,
   };
+};
+
+export const brc20TransferEstimateFees = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+) => {
+  const { chainFee, serviceFee, inscriptionValue, vSize } = await xverseInscribeApi.getBrc20TransferFees(
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+  );
+  return { chainFee, serviceFee, inscriptionValue, vSize };
+};
+
+export const Brc20TransferCreateOrder = async (
+  tick: string,
+  amount: number,
+  revealAddress: string,
+  feeRate: number,
+  network: NetworkType,
+) => {
+  const { commitAddress, commitValue, commitValueBreakdown } = await xverseInscribeApi.createBrc20TransferOrder(
+    tick,
+    amount,
+    revealAddress,
+    feeRate,
+    network,
+  );
+  return { commitAddress, commitValue, commitValueBreakdown };
+};
+
+export const Brc20TransferExecuteOrder = async (commitAddress: string, commitTransactionHex: string) => {
+  const { revealTransactionId, revealUTXOVOut, revealUTXOValue } = await xverseInscribeApi.executeBrc20TransferOrder(
+    commitAddress,
+    commitTransactionHex,
+  );
+  return { revealTransactionId, revealUTXOVOut, revealUTXOValue };
 };

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -98,12 +98,12 @@ export const brc20MintEstimateFees = async (estimateProps: EstimateProps): Promi
 
   const commitValue = new BigNumber(FINAL_SATS_VALUE).plus(revealChainFee).plus(revealServiceFee);
 
-  const bestUtxoData = selectUtxosForSend(
-    dummyAddress,
-    [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
-    addressUtxos,
+  const bestUtxoData = selectUtxosForSend({
+    changeAddress: dummyAddress,
+    recipients: [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
+    availableUtxos: addressUtxos,
     feeRate,
-  );
+  });
 
   if (!bestUtxoData) {
     throw new Error('Not enough funds at selected fee rate');
@@ -141,12 +141,12 @@ export async function brc20MintExecute(executeProps: ExecuteProps): Promise<stri
     FINAL_SATS_VALUE,
   );
 
-  const bestUtxoData = selectUtxosForSend(
+  const bestUtxoData = selectUtxosForSend({
     changeAddress,
-    [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
-    addressUtxos,
+    recipients: [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
+    availableUtxos: addressUtxos,
     feeRate,
-  );
+  });
 
   if (!bestUtxoData) {
     throw new Error('Not enough funds at selected fee rate');
@@ -212,12 +212,12 @@ export const brc20TransferEstimateFees = async (estimateProps: EstimateProps): P
 
   const commitValue = inscriptionValue.plus(revealChainFee).plus(revealServiceFee);
 
-  const bestUtxoData = selectUtxosForSend(
-    dummyAddress,
-    [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
-    addressUtxos,
+  const bestUtxoData = selectUtxosForSend({
+    changeAddress: dummyAddress,
+    recipients: [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
+    availableUtxos: addressUtxos,
     feeRate,
-  );
+  });
 
   if (!bestUtxoData) {
     throw new Error('Not enough funds at selected fee rate');
@@ -310,12 +310,12 @@ export async function* brc20TransferExecute(executeProps: ExecuteProps & { recip
 
   yield ExecuteTransferProgressCodes.CreatingCommitTransaction;
 
-  const bestUtxoData = selectUtxosForSend(
+  const bestUtxoData = selectUtxosForSend({
     changeAddress,
-    [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
-    addressUtxos,
+    recipients: [{ address: revealAddress, amountSats: new BigNumber(commitValue) }],
+    availableUtxos: addressUtxos,
     feeRate,
-  );
+  });
 
   if (!bestUtxoData) {
     throw new Error('Not enough funds at selected fee rate');

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -1,8 +1,12 @@
 import { base64 } from '@scure/base';
-import { NetworkType } from 'types';
+import BigNumber from 'bignumber.js';
+import { NetworkType, UTXO } from 'types';
 import { createInscriptionRequest } from '../api';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import xverseInscribeApi from '../api/xverseInscribe';
+import { calculateFee, generateSignedBtcTransaction } from './btc';
+
+const RECIPIENT_SATS_VALUE = 1000;
 
 const createTransferInscriptionContent = (token: string, amount: string) => ({
   p: 'brc-20',
@@ -15,6 +19,7 @@ const btcClient = new BitcoinEsploraApiProvider({
   network: 'Mainnet',
 });
 
+// TODO: deprecate
 export const createBrc20TransferOrder = async (token: string, amount: string, recipientAddress: string) => {
   const transferInscriptionContent = createTransferInscriptionContent(token, amount);
   const contentB64 = base64.encode(Buffer.from(JSON.stringify(transferInscriptionContent)));
@@ -36,41 +41,165 @@ export const createBrc20TransferOrder = async (token: string, amount: string, re
 };
 
 export const brc20TransferEstimateFees = async (
+  selectedUtxos: Array<UTXO>,
   tick: string,
   amount: number,
   revealAddress: string,
   feeRate: number,
 ) => {
-  const { chainFee, serviceFee, inscriptionValue, vSize } = await xverseInscribeApi.getBrc20TransferFees(
+  const finalRecipientUtxoValue = new BigNumber(RECIPIENT_SATS_VALUE);
+  const transferFeeEstimate = await calculateFee(
+    [{ address: revealAddress, status: { confirmed: false }, txid: '', vout: 0, value: RECIPIENT_SATS_VALUE }],
+    finalRecipientUtxoValue,
+    [{ address: revealAddress, amountSats: finalRecipientUtxoValue }],
+    new BigNumber(feeRate),
+    revealAddress,
+    'Mainnet',
+  );
+
+  const inscriptionValue = finalRecipientUtxoValue.plus(transferFeeEstimate);
+
+  const { chainFee: revealChainFee, serviceFee: revealServiceFee } = await xverseInscribeApi.getBrc20TransferFees(
     tick,
     amount,
     revealAddress,
     feeRate,
+    inscriptionValue.toNumber(),
   );
-  return { chainFee, serviceFee, inscriptionValue, vSize };
+
+  const commitValue = inscriptionValue.plus(revealChainFee).plus(revealServiceFee);
+  const commitChainFees = await calculateFee(
+    selectedUtxos,
+    commitValue,
+    [{ address: revealAddress, amountSats: finalRecipientUtxoValue }],
+    new BigNumber(feeRate),
+    revealAddress,
+    'Mainnet',
+  );
+
+  return {
+    commitValue: commitValue.plus(commitChainFees).toNumber(),
+    valueBreakdown: {
+      commitChainFee: commitChainFees.toNumber(),
+      revealChainFee,
+      revealServiceFee,
+      transferChainFee: transferFeeEstimate.toNumber(),
+      transferUtxoValue: finalRecipientUtxoValue.toNumber(),
+    },
+  };
 };
 
-export const Brc20TransferCreateOrder = async (
+export enum ExecuteTransferProgressCodes {
+  CreatingInscriptionOrder = 'CreatingInscriptionOrder',
+  CreatingCommitTransaction = 'CreatingCommitTransaction',
+  ExecutingInscriptionOrder = 'ExecutingInscriptionOrder',
+  CreatingTransferTransaction = 'CreatingTransferTransaction',
+  Finalizing = 'Finalizing',
+}
+
+export async function* Brc20TransferExecute(
+  privateKey: string,
+  selectedUtxos: Array<UTXO>,
   tick: string,
   amount: number,
   revealAddress: string,
-  feeRate: number,
+  recipientAddress: string,
+  feeRate: BigNumber,
   network: NetworkType,
-) => {
-  const { commitAddress, commitValue, commitValueBreakdown } = await xverseInscribeApi.createBrc20TransferOrder(
-    tick,
-    amount,
-    revealAddress,
+): AsyncGenerator<ExecuteTransferProgressCodes, string, never> {
+  const esploraClient = new BitcoinEsploraApiProvider({ network });
+
+  yield ExecuteTransferProgressCodes.CreatingInscriptionOrder;
+
+  const finalRecipientUtxoValue = new BigNumber(RECIPIENT_SATS_VALUE);
+  const transferFeeEstimate = await calculateFee(
+    [{ address: revealAddress, status: { confirmed: false }, txid: '', vout: 0, value: RECIPIENT_SATS_VALUE }],
+    finalRecipientUtxoValue,
+    [{ address: recipientAddress, amountSats: finalRecipientUtxoValue }],
     feeRate,
+    revealAddress,
     network,
   );
-  return { commitAddress, commitValue, commitValueBreakdown };
-};
 
-export const Brc20TransferExecuteOrder = async (commitAddress: string, commitTransactionHex: string) => {
+  const inscriptionValue = finalRecipientUtxoValue.plus(transferFeeEstimate);
+
+  const { commitAddress, commitValue } = await xverseInscribeApi.createBrc20TransferOrder(
+    tick,
+    amount,
+    revealAddress,
+    feeRate.toNumber(),
+    network,
+    inscriptionValue.toNumber(),
+  );
+
+  yield ExecuteTransferProgressCodes.CreatingCommitTransaction;
+
+  const commitChainFees = await calculateFee(
+    selectedUtxos,
+    new BigNumber(commitValue),
+    [{ address: recipientAddress, amountSats: finalRecipientUtxoValue }],
+    feeRate,
+    revealAddress,
+    network,
+  );
+
+  // This should be:
+  // final transfer value that the recipient will receive in their UTXO + final transfer fees
+  // + reveal service fees + reveal chain fees
+  // + commit chain fees
+  const totalCommitValueSats = new BigNumber(commitValue).plus(commitChainFees);
+
+  const commitTransaction = await generateSignedBtcTransaction(
+    privateKey,
+    selectedUtxos,
+    totalCommitValueSats,
+    [
+      {
+        address: commitAddress,
+        amountSats: totalCommitValueSats,
+      },
+    ],
+    revealAddress,
+    commitChainFees,
+    network,
+  );
+
+  yield ExecuteTransferProgressCodes.ExecutingInscriptionOrder;
+
   const { revealTransactionId, revealUTXOVOut, revealUTXOValue } = await xverseInscribeApi.executeBrc20TransferOrder(
     commitAddress,
-    commitTransactionHex,
+    commitTransaction.hex,
   );
-  return { revealTransactionId, revealUTXOVOut, revealUTXOValue };
-};
+
+  yield ExecuteTransferProgressCodes.CreatingTransferTransaction;
+  const transferTransaction = await generateSignedBtcTransaction(
+    privateKey,
+    [
+      {
+        address: revealAddress,
+        status: {
+          confirmed: false,
+        },
+        txid: revealTransactionId,
+        vout: revealUTXOVOut,
+        value: revealUTXOValue,
+      },
+    ],
+    finalRecipientUtxoValue,
+    [
+      {
+        address: recipientAddress,
+        amountSats: finalRecipientUtxoValue,
+      },
+    ],
+    revealAddress,
+    transferFeeEstimate,
+    network,
+  );
+
+  yield ExecuteTransferProgressCodes.Finalizing;
+
+  const response = await esploraClient.sendRawTransaction(transferTransaction.hex);
+
+  return response.tx.hash;
+}

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -97,7 +97,7 @@ export enum ExecuteTransferProgressCodes {
   Finalizing = 'Finalizing',
 }
 
-export async function* Brc20TransferExecute(
+export async function* brc20TransferExecute(
   privateKey: string,
   selectedUtxos: Array<UTXO>,
   tick: string,

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -79,6 +79,7 @@ export const brc20MintEstimateFees = async (
       commitChainFee: commitChainFees,
       revealChainFee,
       revealServiceFee,
+      inscriptionValue: FINAL_SATS_VALUE,
     },
   };
 };

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -138,7 +138,7 @@ export async function* brc20TransferExecute(
   yield ExecuteTransferProgressCodes.CreatingInscriptionOrder;
 
   const finalRecipientUtxoValue = new BigNumber(RECIPIENT_SATS_VALUE);
-  const { tx } = await await signNonOrdinalBtcSendTransaction(
+  const { tx } = await signNonOrdinalBtcSendTransaction(
     recipientAddress,
     [
       {

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -146,7 +146,7 @@ export async function* brc20TransferExecute(
 
   yield ExecuteTransferProgressCodes.CreatingCommitTransaction;
 
-  const selectedUtxos = selectUnspentOutputs(commitValue, addressUtxos);
+  const selectedUtxos = selectUnspentOutputs(new BigNumber(commitValue), addressUtxos);
 
   const commitChainFees = await calculateFee(
     selectedUtxos,

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -1,14 +1,14 @@
 // import { payments, networks, Psbt, Payment, Transaction } from 'bitcoinjs-lib';
 // import { ECPairFactory } from 'ecpair';
-import BigNumber from 'bignumber.js';
-import { ErrorCodes, NetworkType, ResponseError, BtcFeeResponse, UTXO } from '../types';
-import { fetchBtcFeeRate } from '../api/xverse';
-import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
-import * as btc from '@scure/btc-signer';
-import { hex } from '@scure/base';
 import * as secp256k1 from '@noble/secp256k1';
-import { BitcoinNetwork, getBtcNetwork } from './btcNetwork';
+import { hex } from '@scure/base';
+import * as btc from '@scure/btc-signer';
+import BigNumber from 'bignumber.js';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import { fetchBtcFeeRate } from '../api/xverse';
+import { BtcFeeResponse, ErrorCodes, NetworkType, ResponseError, UTXO } from '../types';
+import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
+import { BitcoinNetwork, getBtcNetwork } from './btcNetwork';
 
 const MINIMUM_CHANGE_OUTPUT_SATS = 1000;
 
@@ -159,7 +159,7 @@ export async function generateSignedBtcTransaction(
     throw new ResponseError(ErrorCodes.InSufficientBalanceWithTxFee).statusCode;
   }
 
-  const changeSats = sumValue.minus(satsToSend);
+  const changeSats = sumValue.minus(satsToSend).minus(feeSats);
 
   addInputs(tx, selectedUnspentOutputs, p2sh);
 
@@ -476,6 +476,7 @@ export function createTransaction(
   recipients: Array<Recipient>,
   changeAddress: string,
   network: NetworkType,
+  skipChange = false,
 ): btc.Transaction {
   // Create Bitcoin transaction
   const tx = new btc.Transaction();
@@ -501,11 +502,202 @@ export function createTransaction(
   });
 
   // Add change output
-  if (changeSats.gt(new BigNumber(MINIMUM_CHANGE_OUTPUT_SATS))) {
+  if (!skipChange && changeSats.gt(new BigNumber(MINIMUM_CHANGE_OUTPUT_SATS))) {
     addOutput(tx, changeAddress, changeSats, btcNetwork);
   }
 
   return tx;
+}
+
+function getTransactionMetadataForUtxos(
+  recipients: Recipient[],
+  selectedUtxos: UTXO[],
+  changeAddress: string,
+  feeRate: number,
+): TransactionUtxoSelectionMetadata | undefined {
+  const dummyPrivateKey = '0000000000000000000000000000000000000000000000000000000000000001';
+
+  const inputSum = selectedUtxos.reduce<BigNumber>((sum, utxo) => sum.plus(utxo.value), new BigNumber(0));
+  const recipientTotal = recipients.reduce<BigNumber>(
+    (sum, recipient) => sum.plus(recipient.amountSats),
+    new BigNumber(0),
+  );
+
+  // these are conservative estimates
+  const ESTIMATED_VBYTES_PER_OUTPUT = 45; // actually around 50
+  const ESTIMATED_VBYTES_PER_INPUT = 85; // actually around 89 or 90
+  const BITCOIN_DUST_VALUE = 1000;
+
+  const estimatedFees = new BigNumber(feeRate).times(
+    ESTIMATED_VBYTES_PER_OUTPUT * recipients.length + ESTIMATED_VBYTES_PER_INPUT * selectedUtxos.length,
+  );
+  // ensure that the UTXOs can cover the expected outputs
+  if (!inputSum.gt(recipientTotal.plus(estimatedFees))) return undefined;
+
+  {
+    // try transaction with change
+    const tx = createTransaction(dummyPrivateKey, selectedUtxos, recipientTotal, recipients, changeAddress, 'Mainnet');
+
+    tx.sign(hex.decode(dummyPrivateKey));
+    tx.finalize();
+
+    const txSize = tx.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < tx.outputsLength; i++) {
+      const output = tx.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const change = sentSats.minus(recipientTotal);
+    const fee = new BigNumber(txSize).times(feeRate);
+
+    // check if there is change and if the change is greater than the vsize*feeRate + dust rate
+    if (change.gt(fee.plus(BITCOIN_DUST_VALUE))) {
+      const changeWithoutFee = change.minus(fee);
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: feeRate,
+        change: changeWithoutFee.toNumber(),
+      };
+    }
+  }
+
+  {
+    // try txn without change
+    const txNoChange = createTransaction(
+      dummyPrivateKey,
+      selectedUtxos,
+      recipientTotal,
+      recipients,
+      changeAddress,
+      'Mainnet',
+      true,
+    );
+
+    txNoChange.sign(hex.decode(dummyPrivateKey));
+    txNoChange.finalize();
+
+    const txSize = txNoChange.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < txNoChange.outputsLength; i++) {
+      const output = txNoChange.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const fee = inputSum.minus(sentSats);
+
+    if (fee.div(txSize).gt(feeRate)) {
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: fee.div(txSize).toNumber(),
+        change: 0,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function selectOptimalUtxos(
+  recipients: Recipient[],
+  selectedUtxos: UTXO[],
+  availableUtxos: UTXO[],
+  changeAddress: string,
+  feeRate: number,
+  currentBestUtxoCount: number | undefined = undefined,
+): TransactionUtxoSelectionMetadata | undefined {
+  const currentSelectionData = getTransactionMetadataForUtxos(recipients, selectedUtxos, changeAddress, feeRate);
+
+  // if there is a valid selection, adding more UTXOs would only make the fees higher, so just return
+  if (currentSelectionData) return currentSelectionData;
+
+  if (availableUtxos.length === 0 || currentBestUtxoCount === selectedUtxos.length - 1) {
+    // we either have no more UTXOs to add or adding would make an existing outer selection worse, so we bail
+    return undefined;
+  }
+
+  // sort smallest to biggest so we can pop biggest from end
+  const sortedUtxos = [...availableUtxos];
+  sortedUtxos.sort((a, b) => a.value - b.value);
+
+  let bestSelectionData: TransactionUtxoSelectionMetadata | undefined = undefined;
+  while (sortedUtxos.length > 0) {
+    const utxo = sortedUtxos.pop() as UTXO;
+
+    const nextSelectionData = selectOptimalUtxos(
+      recipients,
+      [...selectedUtxos, utxo],
+      sortedUtxos,
+      changeAddress,
+      feeRate,
+      currentBestUtxoCount ?? bestSelectionData?.selectedUtxos.length,
+    );
+
+    if (!nextSelectionData) return bestSelectionData;
+
+    /**
+     * we want to:
+     * - minimise fees
+     * - have zero change or maximise change
+     * - while staying above the selected fee rate
+     **/
+    if (!bestSelectionData) {
+      bestSelectionData = nextSelectionData;
+    } else if (bestSelectionData.fee > nextSelectionData.fee) {
+      bestSelectionData = nextSelectionData;
+    } else if (nextSelectionData.fee === bestSelectionData.fee) {
+      if (bestSelectionData.change < nextSelectionData.change) {
+        bestSelectionData = nextSelectionData;
+      }
+    } else {
+      return bestSelectionData;
+    }
+  }
+
+  return bestSelectionData;
+}
+
+type TransactionUtxoSelectionMetadata = {
+  selectedUtxos: UTXO[];
+  fee: number;
+  feeRate: number;
+  change: number;
+};
+
+/**
+ * Finds the optimal combination of UTXOs to send the given amount to the given recipients while minimizing fees,
+ * yet staying above the desired fee rate.
+ */
+export function selectUtxosForSend(
+  changeAddress: string,
+  recipients: Recipient[],
+  availableUtxos: UTXO[],
+  feeRate: number,
+  pinnedUtxos: UTXO[] = [],
+): TransactionUtxoSelectionMetadata | undefined {
+  if (recipients.length === 0) {
+    throw new Error('Must have at least one recipient');
+  }
+
+  if (feeRate <= 0) {
+    throw new Error('Fee rate must be a positive number');
+  }
+
+  const pinnedLocations = new Set(pinnedUtxos.map((utxo) => `${utxo.txid}:${utxo.vout}`));
+
+  const sortedUtxos = availableUtxos.filter((utxo) => {
+    const utxoLocation = `${utxo.txid}:${utxo.vout}`;
+    return !pinnedLocations.has(utxoLocation);
+  });
+  sortedUtxos.sort((a, b) => a.value - b.value);
+
+  const selectedUtxoData = selectOptimalUtxos(recipients, pinnedUtxos, sortedUtxos, changeAddress, feeRate);
+
+  return selectedUtxoData;
 }
 
 export function createOrdinalTransaction(
@@ -826,34 +1018,30 @@ export async function signNonOrdinalBtcSendTransaction(
     calculatedFee = fee;
   }
 
-  try {
-    const tx = new btc.Transaction();
-    const btcNetwork = getBtcNetwork(network);
+  const tx = new btc.Transaction();
+  const btcNetwork = getBtcNetwork(network);
 
-    // Create spend
-    const taprootInternalPubKey = secp256k1.schnorr.getPublicKey(taprootPrivateKey);
-    const p2tr = btc.p2tr(taprootInternalPubKey, undefined, btcNetwork);
+  // Create spend
+  const taprootInternalPubKey = secp256k1.schnorr.getPublicKey(taprootPrivateKey);
+  const p2tr = btc.p2tr(taprootInternalPubKey, undefined, btcNetwork);
 
-    addInputsTaproot(tx, selectedUnspentOutputs, taprootInternalPubKey, p2tr);
+  addInputsTaproot(tx, selectedUnspentOutputs, taprootInternalPubKey, p2tr);
 
-    // Add outputs
-    recipients.forEach((recipient) => {
-      addOutput(tx, recipient.address, recipient.amountSats.minus(calculatedFee), btcNetwork);
-    });
+  // Add outputs
+  recipients.forEach((recipient) => {
+    addOutput(tx, recipient.address, recipient.amountSats.minus(calculatedFee), btcNetwork);
+  });
 
-    // Sign inputs
-    tx.sign(hex.decode(taprootPrivateKey));
-    tx.finalize();
+  // Sign inputs
+  tx.sign(hex.decode(taprootPrivateKey));
+  tx.finalize();
 
-    const signedBtcTx: SignedBtcTx = {
-      tx: tx,
-      signedTx: tx.hex,
-      fee: fee ?? calculatedFee,
-      total: sumSelectedOutputs,
-    };
+  const signedBtcTx: SignedBtcTx = {
+    tx: tx,
+    signedTx: tx.hex,
+    fee: fee ?? calculatedFee,
+    total: sumSelectedOutputs,
+  };
 
-    return await Promise.resolve(signedBtcTx);
-  } catch (error) {
-    return Promise.reject(error.toString());
-  }
+  return signedBtcTx;
 }

--- a/transactions/index.ts
+++ b/transactions/index.ts
@@ -26,9 +26,9 @@ import {
 } from './stx';
 
 import {
-  Brc20TransferCreateOrder,
-  Brc20TransferExecuteOrder,
+  ExecuteTransferProgressCodes,
   brc20TransferEstimateFees,
+  brc20TransferExecute,
   createBrc20TransferOrder,
 } from './brc20';
 import type { PSBTInput, PSBTOutput, ParsedPSBT } from './psbt';
@@ -40,10 +40,10 @@ import {
 } from './stacking';
 
 export {
-  Brc20TransferCreateOrder,
-  Brc20TransferExecuteOrder,
+  ExecuteTransferProgressCodes,
   addressToString,
   brc20TransferEstimateFees,
+  brc20TransferExecute,
   broadcastSignedTransaction,
   createBrc20TransferOrder,
   createContractCallPromises,

--- a/transactions/index.ts
+++ b/transactions/index.ts
@@ -25,7 +25,12 @@ import {
   signTransaction,
 } from './stx';
 
-import { createBrc20TransferOrder } from './brc20';
+import {
+  Brc20TransferCreateOrder,
+  Brc20TransferExecuteOrder,
+  brc20TransferEstimateFees,
+  createBrc20TransferOrder,
+} from './brc20';
 import type { PSBTInput, PSBTOutput, ParsedPSBT } from './psbt';
 import { parsePsbt } from './psbt';
 import {
@@ -35,7 +40,10 @@ import {
 } from './stacking';
 
 export {
+  Brc20TransferCreateOrder,
+  Brc20TransferExecuteOrder,
   addressToString,
+  brc20TransferEstimateFees,
   broadcastSignedTransaction,
   createBrc20TransferOrder,
   createContractCallPromises,

--- a/types/api/xverseInscribe/brc20.ts
+++ b/types/api/xverseInscribe/brc20.ts
@@ -46,10 +46,22 @@ export type Brc20CreateOrderResponse = {
 export type Brc20ExecuteOrderRequest = {
   commitAddress: string;
   commitTransactionHex: string;
+  skipFinalize?: boolean;
 };
 
 export type Brc20ExecuteOrderResponse = {
   revealTransactionId: string;
   revealUTXOVOut: 0;
   revealUTXOValue: number;
+};
+
+export type Brc20FinalizeTransferOrderRequest = {
+  commitAddress: string;
+  transferTransactionHex: string;
+};
+
+export type Brc20FinalizeTransferOrderResponse = {
+  commitTransactionId: string;
+  revealTransactionId: string;
+  transferTransactionId: string;
 };

--- a/types/api/xverseInscribe/brc20.ts
+++ b/types/api/xverseInscribe/brc20.ts
@@ -1,0 +1,53 @@
+import { NetworkType } from 'types/network';
+
+type Brc20TransferOrMintRequest = {
+  operation: 'transfer' | 'mint';
+  tick: string;
+  amount: number;
+};
+
+type Brc20DeployRequest = {
+  operation: 'deploy';
+  tick: string;
+  max: number;
+  lim: number;
+};
+
+export type Brc20CostEstimateRequest = (Brc20TransferOrMintRequest | Brc20DeployRequest) & {
+  revealAddress: string;
+  feeRate: number;
+};
+
+export type Brc20CostEstimateResponse = {
+  inscriptionValue: number;
+  chainFee: number;
+  serviceFee: number;
+  vSize: number;
+};
+
+export type Brc20CreateOrderRequest = (Brc20TransferOrMintRequest | Brc20DeployRequest) & {
+  revealAddress: string;
+  feeRate: number;
+  network: NetworkType;
+};
+
+export type Brc20CreateOrderResponse = {
+  commitAddress: string;
+  commitValue: number;
+  commitValueBreakdown: {
+    inscriptionValue: number;
+    chainFee: number;
+    serviceFee: number;
+  };
+};
+
+export type Brc20ExecuteOrderRequest = {
+  commitAddress: string;
+  commitTransactionHex: string;
+};
+
+export type Brc20ExecuteOrderResponse = {
+  revealTransactionId: string;
+  revealUTXOVOut: 0;
+  revealUTXOValue: number;
+};

--- a/types/api/xverseInscribe/brc20.ts
+++ b/types/api/xverseInscribe/brc20.ts
@@ -16,6 +16,7 @@ type Brc20DeployRequest = {
 export type Brc20CostEstimateRequest = (Brc20TransferOrMintRequest | Brc20DeployRequest) & {
   revealAddress: string;
   feeRate: number;
+  inscriptionValue?: number;
 };
 
 export type Brc20CostEstimateResponse = {
@@ -29,6 +30,7 @@ export type Brc20CreateOrderRequest = (Brc20TransferOrMintRequest | Brc20DeployR
   revealAddress: string;
   feeRate: number;
   network: NetworkType;
+  inscriptionValue?: number;
 };
 
 export type Brc20CreateOrderResponse = {

--- a/types/api/xverseInscribe/index.ts
+++ b/types/api/xverseInscribe/index.ts
@@ -1,0 +1,1 @@
+export * from './brc20';

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,6 +44,7 @@ export * from './api/xverse/sponsor';
 export type { Pool, StackerInfo, StackingData, StackingPoolInfo, StackingStateData } from './api/xverse/stacking';
 export * from './api/xverse/transaction';
 export * from './api/xverse/wallet';
+export * from './api/xverseInscribe';
 export type { SupportedCurrency } from './currency';
 export * from './error';
 export * from './network';


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background
This adds the calls to the Xverse inscribe api  to enable 1 step BRC20 transfers.

Issue Link: ENG-2391

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- Added calls to the inscribe service for brc20 transfer fee estimation, order creation and order execution.
- No breaking changes
 
Impact:
- With these endpoints we will be able to make 1-step brc20 transfers

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
