### PR TITLE
Add utils for displaying Brc20 token transaction history

### DIFF
--- a/api/helper.ts
+++ b/api/helper.ts
@@ -7,6 +7,8 @@ import {
   StxTransactionDataResponse,
   StxMempoolTransactionDataResponse,
   TransferTransaction,
+  Brc20HistoryTransactionData,
+  OrdinalTokenTransaction,
 } from '../types';
 
 import * as esplora from '../types/api/esplora';
@@ -148,6 +150,23 @@ export function parseBtcTransactionData(
     recipientAddress: outputAddresses[0],
   };
 
+  return parsedTx;
+}
+
+export function parseBrc20TransactionData(responseTx: OrdinalTokenTransaction): Brc20HistoryTransactionData {
+  const incoming = responseTx.type === 'receive';
+
+  const date = new Date(0);
+  if (responseTx.blocktime) date.setUTCSeconds(responseTx.blocktime);
+
+  const parsedTx: Brc20HistoryTransactionData = {
+    ...responseTx,
+    amount: new BigNumber(responseTx.amount),
+    seenTime: date,
+    incoming,
+    txType: 'brc20',
+    txStatus: 'success',
+  };
   return parsedTx;
 }
 

--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -5,7 +5,9 @@ import {
   FungibleToken,
   InscriptionRequestResponse,
   Inscription,
-  Account
+  Account,
+  Brc20HistoryTransactionData,
+  OrdinalTokenTransaction
 } from '../types';
 import axios from 'axios';
 import { 
@@ -15,6 +17,7 @@ import {
   INSCRIPTION_REQUESTS_SERVICE_URL
 } from '../constant';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import { parseBrc20TransactionData } from './helper';
 
 export function parseOrdinalTextContentData(content: string): string {
   try {
@@ -162,6 +165,24 @@ export async function getOrdinalsFtBalance(
     });
 }
 
+export async function getBrc20History(address: string, token: string): Promise<Brc20HistoryTransactionData[]> {
+  const url = `${XVERSE_API_BASE_URL}/v1/ordinals/token/${token}/history/${address}`;
+  return axios
+    .get(url, {
+      timeout: 30000,
+    })
+    .then((response) => {
+      const data: OrdinalTokenTransaction[] = response.data;
+      const transactions: Brc20HistoryTransactionData[] = [];
+      data.forEach((tx) => {
+        transactions.push(parseBrc20TransactionData(tx));
+      });
+      return transactions;
+    })
+    .catch((error) => {
+      return [];
+    });
+}
 
 export async function createInscriptionRequest(
   recipientAddress: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/types/api/ordinals/index.ts
+++ b/types/api/ordinals/index.ts
@@ -1,3 +1,5 @@
+import { TransactionData } from "../xverse/transaction";
+
 export interface Inscription {
   id: string;
   number: number;
@@ -27,4 +29,46 @@ export interface InscriptionsList {
   offset: number;
   total: number;
   results: Inscription[];
+}
+
+export interface OrdinalTokenTransaction {
+  amount: string;
+  availableBalance: string;
+  blockhash: string;
+  blocktime: number;
+  from: string;
+  height: number;
+  idx: number;
+  inscriptionId: string;
+  inscriptionNumber: number;
+  overallBalance: string;
+  satoshi: number;
+  ticker: string;
+  to: string;
+  transferBalance: string;
+  txid: string;
+  txidx: number;
+  type: string;
+  valid: boolean;
+  vout: number;
+}
+
+export interface Brc20HistoryTransactionData extends TransactionData {
+  availableBalance: string;
+  blockhash: string;
+  blocktime: number;
+  from: string;
+  height: number;
+  idx: number;
+  inscriptionId: string;
+  inscriptionNumber: number;
+  overallBalance: string;
+  satoshi: number;
+  ticker: string;
+  to: string;
+  transferBalance: string;
+  txidx: number;
+  type: string;
+  valid: boolean;
+  vout: number;
 }

--- a/types/api/shared/transaction.ts
+++ b/types/api/shared/transaction.ts
@@ -5,7 +5,8 @@ export type TransactionType =
   | 'coinbase'
   | 'poison_microblock'
   | 'bitcoin'
-  | 'unsupported';
+  | 'unsupported'
+  | 'brc20';
 
 export type TransactionStatus =
   | 'pending'


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
We want to display the transaction history for BRC20 tokens. 

Issue Link: https://linear.app/xverseapp/issue/ENG-2459/brc-20-display-transaction-history


# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
The PR uses the api endpoint `/v1/ordinals/token/${token}/history/${address}` to get the history for a user's token and includes a function to parse the response from api in order to be used by the extension. 

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
