### PR TITLE
Switch to xord with fallback to hiro

### DIFF
--- a/api/ordinals/provider.ts
+++ b/api/ordinals/provider.ts
@@ -1,9 +1,8 @@
-
-import { HIRO_MAINNET_DEFAULT, HIRO_TESTNET_DEFAULT } from '../../constant';
-import { NetworkType } from '../../types/network';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, Method } from 'axios';
+import { HIRO_MAINNET_DEFAULT, HIRO_TESTNET_DEFAULT, XORD_MAINNET_URL } from '../../constant';
 import * as ordinalsType from '../../types/api/ordinals';
+import { NetworkType } from '../../types/network';
 import { OrdinalsApiProvider } from './types';
-import ApiInstance from '../instance';
 
 export interface OrdinalsApiProviderOptions {
   network: NetworkType;
@@ -12,29 +11,128 @@ export interface OrdinalsApiProviderOptions {
 
 const API_PREFIX = '/ordinals/v1/';
 
-export default class OrdinalsApi extends ApiInstance implements OrdinalsApiProvider {
-  _network: NetworkType;
+// if we fallback to hiro, we'll use it at maximum this many times before trying the other API
+const MAX_FALLBACK_CALLS = 10;
+
+export default class OrdinalsApi implements OrdinalsApiProvider {
+  private network: NetworkType;
+
+  private customClient?: AxiosInstance;
+
+  private hiroClient!: AxiosInstance;
+
+  private xordClient?: AxiosInstance;
+
+  private fallbackCalls = 0;
 
   constructor(options: OrdinalsApiProviderOptions) {
     const { url, network } = options;
-    super({
-      baseURL:
-        `${url}${API_PREFIX}` || network == 'Mainnet'
-          ? `${HIRO_MAINNET_DEFAULT}${API_PREFIX}`
-          : `${HIRO_TESTNET_DEFAULT}${API_PREFIX}`,
-    });
-    this._network = network;
+    this.network = network;
+
+    if (url) {
+      this.customClient = axios.create({
+        baseURL: `${url}${API_PREFIX}`,
+      });
+    }
+
+    if (network == 'Mainnet') {
+      this.hiroClient = axios.create({
+        baseURL: `${HIRO_MAINNET_DEFAULT}${API_PREFIX}`,
+      });
+
+      this.xordClient = axios.create({
+        baseURL: `${XORD_MAINNET_URL}/v1`,
+      });
+    } else {
+      this.hiroClient = axios.create({
+        baseURL: `${HIRO_TESTNET_DEFAULT}${API_PREFIX}`,
+      });
+    }
+  }
+
+  private canFallback(): boolean {
+    return !this.customClient && !!this.xordClient;
+  }
+
+  private shouldFallback(fallback = false): boolean {
+    if (!this.canFallback()) return false;
+
+    const shouldFallback = fallback || (this.fallbackCalls > 0 && this.fallbackCalls <= MAX_FALLBACK_CALLS);
+
+    if (!shouldFallback) {
+      this.fallbackCalls = 0;
+    } else {
+      this.fallbackCalls += 1;
+    }
+
+    return shouldFallback;
+  }
+
+  private getClient(shouldFallback: boolean): AxiosInstance {
+    if (this.customClient) return this.customClient;
+
+    if (!this.xordClient || shouldFallback) return this.hiroClient;
+
+    return this.xordClient;
+  }
+
+  private async httpCall<T>(
+    method: Method,
+    url: string,
+    reqConfig?: Omit<AxiosRequestConfig, 'url' | 'baseUrl' | 'method'>,
+  ): Promise<T> {
+    let shouldFallback = this.shouldFallback();
+
+    let client = this.getClient(shouldFallback);
+    const callParams = {
+      method,
+      url,
+      ...reqConfig,
+    };
+
+    try {
+      const response = await client.request<T>(callParams);
+
+      return response.data;
+    } catch (err) {
+      const error = err as AxiosError;
+
+      if ((shouldFallback || error.response?.status) ?? 0 < 500) {
+        // we have already fallen back or the error is not server related
+        throw error;
+      }
+
+      shouldFallback = this.shouldFallback(true);
+
+      if (!shouldFallback) {
+        // we cannot fallback
+        throw error;
+      }
+
+      client = this.getClient(shouldFallback);
+
+      const response = await client.request<T>(callParams);
+
+      return response.data;
+    }
   }
 
   async getInscriptions(address: string, offset: number, limit: number): Promise<ordinalsType.InscriptionsList> {
-    const data: ordinalsType.InscriptionsList = await this.httpGet(
-      `inscriptions?address=${address}&offset=${offset}&limit=${limit}`
-    );
+    const url = 'inscriptions';
+    const params = {
+      address,
+      offset,
+      limit,
+    };
+
+    const data = await this.httpCall<ordinalsType.InscriptionsList>('get', url, { params });
+
     return data;
   }
 
   async getInscription(inscriptionId: string): Promise<ordinalsType.Inscription> {
-    const inscription: ordinalsType.Inscription = await this.httpGet(`inscriptions/${inscriptionId}`);
+    const url = `inscriptions/${inscriptionId}`;
+    const inscription = await this.httpCall<ordinalsType.Inscription>('get', url);
     return inscription;
   }
 }

--- a/constant.ts
+++ b/constant.ts
@@ -90,8 +90,7 @@ export const supportedCoins = [
     name: 'SLIME',
   },
 ];
-export const ORDINALS_URL = (inscriptionId: string) =>
-  `https://api.hiro.so/ordinals/v1/inscriptions/${inscriptionId}/content`;
+export const ORDINALS_URL = (inscriptionId: string) => `https://ord.xverse.app/content/${inscriptionId}`;
 
 export const ORDINALS_FT_INDEXER_API_URL = 'https://unisat.io/brc20-api-v2/address';
 

--- a/constant.ts
+++ b/constant.ts
@@ -38,56 +38,58 @@ export const XVERSE_SPONSOR_URL = 'https://sponsor.xverse.app';
 
 export const GAIA_HUB_URL = 'https://hub.blockstack.org';
 
+export const XORD_MAINNET_URL = 'https://inscribe.xverse.app';
+
 export const HIRO_MAINNET_DEFAULT = 'https://api.hiro.so';
 
 export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';
 
-export const  supportedCoins =  [
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token",
-        "name": "ALEX"
-    },
-    {
-        "contract": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token",
-        "name": "Arkadiko Token"
-    },
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.auto-alex",
-        "name": "Auto ALEX"
-    },
-    {
-        "contract": "SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2",
-        "name": "MiamiCoin"
-    },
-    {
-        "contract": "SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2",
-        "name": "NewYorkCityCoin"
-    },
-    {
-        "contract": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token",
-        "name": "USDA"
-    },
-    {
-        "contract": "SP27BB1Y2DGSXZHS7G9YHKTSH6KQ6BD3QG0AN3CR9.vibes-token",
-        "name": "Vibes"
-    },
-    {
-        "contract": "SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin",
-        "name": "Wrapped Bitcoin"
-    },
-    {
-        "contract": "SP2TZK01NKDC89J6TA56SA47SDF7RTHYEQ79AAB9A.Wrapped-USD",
-        "name": "Wrapped USD"
-    },
-    {
-        "contract": "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt",
-        "name": "Wrapped USDT"
-    },
-    {
-        "contract": "SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.slime-token",
-        "name": "SLIME"
-    }
-]
+export const supportedCoins = [
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token',
+    name: 'ALEX',
+  },
+  {
+    contract: 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token',
+    name: 'Arkadiko Token',
+  },
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.auto-alex',
+    name: 'Auto ALEX',
+  },
+  {
+    contract: 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2',
+    name: 'MiamiCoin',
+  },
+  {
+    contract: 'SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2',
+    name: 'NewYorkCityCoin',
+  },
+  {
+    contract: 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token',
+    name: 'USDA',
+  },
+  {
+    contract: 'SP27BB1Y2DGSXZHS7G9YHKTSH6KQ6BD3QG0AN3CR9.vibes-token',
+    name: 'Vibes',
+  },
+  {
+    contract: 'SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin',
+    name: 'Wrapped Bitcoin',
+  },
+  {
+    contract: 'SP2TZK01NKDC89J6TA56SA47SDF7RTHYEQ79AAB9A.Wrapped-USD',
+    name: 'Wrapped USD',
+  },
+  {
+    contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt',
+    name: 'Wrapped USDT',
+  },
+  {
+    contract: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.slime-token',
+    name: 'SLIME',
+  },
+];
 export const ORDINALS_URL = (inscriptionId: string) =>
   `https://api.hiro.so/ordinals/v1/inscriptions/${inscriptionId}/content`;
 


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background
Hiro's indexer has a few issues. Some of the IDs are incorrect, Ordinals are assigned to incorrect owners, and it's often behind due to slow indexing.

We've brought up our own API, based on Ord, with the same interface in order to replace the Hiro API. This PR changes the endpoint used for inscription data to be our indexer primarily, and to fall back to Hiro's api if our indexer returns a 50X status code.

Further to this, the URl we retrieved ordinal content from was changed to our ord instance since Hiro's IDs are sometimes incorrect and they wouldn't have the content in the correct URL.

Issue Link: ENG-2478

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
We now use Xord for inscription data and our own ord for image content

Impact:
- Improves reliability and stability of inscriptions
- Needs Core version upgrade in the extension and mobile app

What to test:
- All ordinal images will come from a different source in the ordinal explorer and gallery view
- The list of ordinals for an address now comes from our own API, so gallery list view and wallet ordinals list view are affected
- The data for an ordinal now comes from our API primarily, so the ordinal details screen would have a new data source
- When signing PSBTs, we check if any of the UTXOs have ordinals on them to display a warning. This now comes from our API.

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
