### PR TITLE
Fetch BTC transaction from txId

### DIFF
--- a/api/btc.ts
+++ b/api/btc.ts
@@ -54,3 +54,26 @@ export async function fetchBtcTransactionsData(
   );
   return paymentTransactions;
 }
+
+export async function fetchBtcTransaction(
+  id: string,
+  btcAddress: string,
+  ordinalsAddress: string,
+  network: NetworkType,
+) {
+  const btcClient = new BitcoinEsploraApiProvider({
+    network,
+  });
+  const txResponse: esplora.Transaction = await btcClient.getBtcTransaction(id);
+  const transaction: BtcTransactionData = parseBtcTransactionData(txResponse, btcAddress, ordinalsAddress);
+  return transaction;
+}
+
+export async function fetchOrdinalTransaction(id: string, ordinalsAddress: string, network: NetworkType) {
+  const btcClient = new BitcoinEsploraApiProvider({
+    network,
+  });
+  const txResponse: esplora.Transaction = await btcClient.getBtcTransaction(id);
+  const transaction: BtcTransactionData = parseOrdinalsBtcTransactions(txResponse, ordinalsAddress);
+  return transaction;
+}

--- a/api/btc.ts
+++ b/api/btc.ts
@@ -60,20 +60,14 @@ export async function fetchBtcTransaction(
   btcAddress: string,
   ordinalsAddress: string,
   network: NetworkType,
+  isOrdinal?: boolean,
 ) {
   const btcClient = new BitcoinEsploraApiProvider({
     network,
   });
-  const txResponse: esplora.Transaction = await btcClient.getBtcTransaction(id);
-  const transaction: BtcTransactionData = parseBtcTransactionData(txResponse, btcAddress, ordinalsAddress);
-  return transaction;
-}
-
-export async function fetchOrdinalTransaction(id: string, ordinalsAddress: string, network: NetworkType) {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const txResponse: esplora.Transaction = await btcClient.getBtcTransaction(id);
-  const transaction: BtcTransactionData = parseOrdinalsBtcTransactions(txResponse, ordinalsAddress);
+  const txResponse: esplora.Transaction = await btcClient.getTransaction(id);
+  const transaction: BtcTransactionData = isOrdinal
+    ? parseOrdinalsBtcTransactions(txResponse, ordinalsAddress)
+    : parseBtcTransactionData(txResponse, btcAddress, ordinalsAddress);
   return transaction;
 }

--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -146,6 +146,10 @@ export default class BitcoinEsploraApiProvider extends ApiInstance implements Bi
     return this.httpGet<esplora.Transaction[]>(`/address/${address}/txs`);
   }
 
+  async getBtcTransaction(txid: string): Promise<esplora.Transaction> {
+    return this.httpGet<esplora.Transaction>(`/tx/${txid}`);
+  }
+
   async getAddressMempoolTransactions(address: string): Promise<esplora.BtcAddressMempool[]> {
     return this.httpGet<esplora.BtcAddressMempool[]>(`/address/${address}/txs/mempool`);
   }

--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -146,7 +146,7 @@ export default class BitcoinEsploraApiProvider extends ApiInstance implements Bi
     return this.httpGet<esplora.Transaction[]>(`/address/${address}/txs`);
   }
 
-  async getBtcTransaction(txid: string): Promise<esplora.Transaction> {
+  async getTransaction(txid: string): Promise<esplora.Transaction> {
     return this.httpGet<esplora.Transaction>(`/tx/${txid}`);
   }
 


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
We need functions to fetch individual BTC and Ordinal transaction from txId. We fetch the transaction from transaction status screens to show the transaction detail after the tx is broadcasted successfully. 

Issue Link: https://linear.app/xverseapp/issue/ENG-2480/add-fetch-btc-and-ordinal-transaction-functions
Context Link (if applicable): https://linear.app/xverseapp/issue/ENG-2427/update-transaction-status-screens

# 🔄 Changes
added two functions in api/btc.ts. to fetch BTC and Ordinal transaction from txId. 

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- added functions in api/btc.ts
- no breaking change

Impact:
- adds functionality to fetch individual BTC and Ordinal transactions
- https://github.com/secretkeylabs/xverse/pull/1125 This PR from the mobile app repo depends on this change
- To test this from the mobile app, we need to broadcast simple BTC and Ordinal transaction and see the transaction from Transaction Status scren after the broadcast is successful 

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
