### PR TITLE
fix: valid brc20 transfer logic

### DIFF
--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -189,7 +189,10 @@ export async function createInscriptionRequest(
   return response.data;
 }
 
-export const isBrcTransferValid = (inscription: Inscription) => inscription.address === inscription.genesis_address
+export const isBrcTransferValid = (inscription: Inscription) => {
+  const output: string = inscription.output.split(':')[0];
+  return output === inscription.genesis_tx_id;
+};
 
 export const isOrdinalOwnedByAccount = (inscription: Inscription, account: Account) =>
   inscription.address === account.ordinalsAddress;


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
The logic for valid BRC-20 transfer was not correct

Issue Link: https://linear.app/xverseapp/issue/ENG-2503/fix-valid-brc-20-logic
Context Link (if applicable):

# 🔄 Changes
Updated the function `isBrcTransferValid` logic. 
New logic: If the inscription output is equal to genesis_tx_id, it is a valid BRC-20 transfer.

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- modified function `isBrcTransferValid`
- No breaking change

Impact:
- fixes the BRC-20 transfer status 
- we need to test the status of the BRC20 transfer inscriptions. 

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
