### PR TITLE
feat: add logic for getting best UTXO combo for txn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/tests/transactions/btc.data.ts
+++ b/tests/transactions/btc.data.ts
@@ -1,0 +1,107 @@
+export const utxo10k = {
+  txid: 'bb01711d83a22efcb10a8f025d17e61a09a53fafb22c4faf831df0cbdf104b40',
+  vout: 0,
+  status: {
+    confirmed: true,
+    block_height: 790416,
+    block_hash: '0000000000000000000353903f91b9280da1bfa205469d8fee2d9e79af9a1878',
+    block_time: 1684480442,
+  },
+  value: 10000,
+  address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+};
+
+export const utxo3k = {
+  txid: '758debef5a1930c93ea0a99d3110c78db0a7d26dc5765ae33ab160ebc68f1b39',
+  vout: 0,
+  status: {
+    confirmed: true,
+    block_height: 786775,
+    block_hash: '00000000000000000002104d6d7828d2fbd215e67c443c5da59a311f1ff99321',
+    block_time: 1682311497,
+  },
+  value: 3000,
+  address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+};
+
+export const utxo384k = {
+  txid: '61afc3bed964c4809fd8461c51331993776254752d03f8f51431f27bb4b4a6dc',
+  vout: 0,
+  status: {
+    confirmed: true,
+    block_height: 795007,
+    block_hash: '000000000000000000002ed5bfd475a681dbbfb330b8fdcf1a85e3228ab0370b',
+    block_time: 1687154049,
+  },
+  value: 384000,
+  address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+};
+
+export const utxo792k = {
+  txid: '0c3d764f62b815803a83c4b6df499d4cd02cebe95bb7f1921f241d1626d40b54',
+  vout: 2,
+  status: {
+    confirmed: true,
+    block_height: 794726,
+    block_hash: '00000000000000000002a7b8cf55cf0d82a503ce64f5596ac82df4e7788cd50a',
+    block_time: 1686984560,
+  },
+  value: 792000,
+  address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+};
+
+export const utxos = [
+  utxo10k,
+  utxo3k,
+  utxo384k,
+  utxo792k,
+  // below are dust UTXOs which should never be selected
+  {
+    txid: 'c0979647f08b98dd5e863459bd3b66e7545a87d6dfa377f6437c668fc718861c',
+    vout: 0,
+    status: {
+      confirmed: true,
+      block_height: 786680,
+      block_hash: '00000000000000000000f51440ad69222f84657ffcd454804319af24d6cdc5e3',
+      block_time: 1682256800,
+    },
+    value: 546,
+    address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+  },
+  {
+    txid: 'b11f8946882d156fa0a4c495209bdcc8bbe9aa8aae06ba5954c6f1502eb8b11d',
+    vout: 0,
+    status: {
+      confirmed: true,
+      block_height: 786583,
+      block_hash: '000000000000000000024256567d65bc178eaf22d78938ad5a762602fd003281',
+      block_time: 1682195537,
+    },
+    value: 546,
+    address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+  },
+  {
+    txid: 'aed7a41d0e6f404aa91db1b5bff1b1a75830324c62b28914a30ca8baf895bc84',
+    vout: 0,
+    status: {
+      confirmed: true,
+      block_height: 786814,
+      block_hash: '00000000000000000001ba2c991ae6a5107bbc1aade24d9f3724aac929491e2e',
+      block_time: 1682339651,
+    },
+    value: 546,
+    address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+  },
+  {
+    txid: '6f317fabea61f40a675c8da25cd7907a578e4230ec2d92734eca39c94c4af7e7',
+    vout: 0,
+    status: {
+      confirmed: true,
+      block_height: 786814,
+      block_hash: '00000000000000000001ba2c991ae6a5107bbc1aade24d9f3724aac929491e2e',
+      block_time: 1682339651,
+    },
+    value: 546,
+    address: 'bc1pwl57h24ecsurje63h9mlyema6gk264yrgca5y6klyya8qtqqjt2ql2j2g8',
+  },
+];

--- a/tests/transactions/btc.fixtures.ts
+++ b/tests/transactions/btc.fixtures.ts
@@ -13,7 +13,13 @@ type SelectUtxoSendSuccessExpected = {
   fee: number;
 };
 
-type SelectUtxoSendSuccessFixture = [FixtureName, Recipient[], FeeRate, SelectUtxoSendSuccessExpected];
+type FixtureInput = {
+  recipients: Recipient[];
+  feeRate: FeeRate;
+  expected: SelectUtxoSendSuccessExpected;
+};
+
+type SelectUtxoSendSuccessFixture = [FixtureName, FixtureInput];
 
 export const recipientAddress1 = 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh';
 export const recipientAddress2 = 'bc1pyzfhlkq29sylwlv72ve52w8mn7hclefzhyay3dxh32r0322yx6uqajvr3y';
@@ -21,149 +27,167 @@ export const recipientAddress2 = 'bc1pyzfhlkq29sylwlv72ve52w8mn7hclefzhyay3dxh32
 export const selectUtxosForSendSuccessFixtures: SelectUtxoSendSuccessFixture[] = [
   [
     'Large output, prefer largest UTXO with largest change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(60000),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k],
-      change: 730120,
-      fee: 1880,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(60000),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k],
+        change: 730120,
+        fee: 1880,
+      },
     },
   ],
   [
     'Small output, prefer largest UTXO with largest change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(5000),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k],
-      change: 785120,
-      fee: 1880,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(5000),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k],
+        change: 785120,
+        fee: 1880,
+      },
     },
   ],
   [
     'Exact change output, prefer smaller UTXO with no change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(8170),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo10k],
-      change: 0,
-      fee: 1830,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(8170),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo10k],
+        change: 0,
+        fee: 1830,
+      },
     },
   ],
   [
     'Multiple inputs, prefer large change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(792000),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k, utxo384k],
-      change: 381220,
-      fee: 2780,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(792000),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k, utxo384k],
+        change: 381220,
+        fee: 2780,
+      },
     },
   ],
   [
     'Exact change inputs, multiple UTXOs, prefer no change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(799570),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k, utxo10k],
-      change: 0,
-      fee: 2430,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(799570),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k, utxo10k],
+        change: 0,
+        fee: 2430,
+      },
     },
   ],
   [
     'All inputs, exclude dust',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(1184000),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k, utxo384k, utxo10k, utxo3k],
-      change: 0,
-      fee: 5000,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(1184000),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k, utxo384k, utxo10k, utxo3k],
+        change: 0,
+        fee: 5000,
+      },
     },
   ],
   [
     'Multiple recipients, prefer large change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(20000),
-      },
-      {
-        address: recipientAddress2,
-        amountSats: new BigNumber(30000),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k],
-      change: 739690,
-      fee: 2310,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(20000),
+        },
+        {
+          address: recipientAddress2,
+          amountSats: new BigNumber(30000),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k],
+        change: 739690,
+        fee: 2310,
+      },
     },
   ],
   [
     'Multiple recipients, low value, prefer high change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(5000),
-      },
-      {
-        address: recipientAddress2,
-        amountSats: new BigNumber(1200),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo792k],
-      change: 783490,
-      fee: 2310,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(5000),
+        },
+        {
+          address: recipientAddress2,
+          amountSats: new BigNumber(1200),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo792k],
+        change: 783490,
+        fee: 2310,
+      },
     },
   ],
   [
     'Multiple recipients, exact value, prefer no change',
-    [
-      {
-        address: recipientAddress1,
-        amountSats: new BigNumber(5000),
-      },
-      {
-        address: recipientAddress2,
-        amountSats: new BigNumber(2900),
-      },
-    ],
-    10,
     {
-      selectedUtxos: [utxo10k],
-      change: 0,
-      fee: 2100,
+      recipients: [
+        {
+          address: recipientAddress1,
+          amountSats: new BigNumber(5000),
+        },
+        {
+          address: recipientAddress2,
+          amountSats: new BigNumber(2900),
+        },
+      ],
+      feeRate: 10,
+      expected: {
+        selectedUtxos: [utxo10k],
+        change: 0,
+        fee: 2100,
+      },
     },
   ],
 ];

--- a/tests/transactions/btc.fixtures.ts
+++ b/tests/transactions/btc.fixtures.ts
@@ -1,0 +1,169 @@
+import BigNumber from 'bignumber.js';
+import { UTXO } from 'types';
+import { Recipient } from '../../transactions/btc';
+
+import { utxo10k, utxo384k, utxo3k, utxo792k } from './btc.data';
+
+type FixtureName = string;
+type FeeRate = number;
+
+type SelectUtxoSendSuccessExpected = {
+  selectedUtxos: UTXO[];
+  change: number;
+  fee: number;
+};
+
+type SelectUtxoSendSuccessFixture = [FixtureName, Recipient[], FeeRate, SelectUtxoSendSuccessExpected];
+
+export const recipientAddress1 = 'bc1pgkwmp9u9nel8c36a2t7jwkpq0hmlhmm8gm00kpdxdy864ew2l6zqw2l6vh';
+export const recipientAddress2 = 'bc1pyzfhlkq29sylwlv72ve52w8mn7hclefzhyay3dxh32r0322yx6uqajvr3y';
+
+export const selectUtxosForSendSuccessFixtures: SelectUtxoSendSuccessFixture[] = [
+  [
+    'Large output, prefer largest UTXO with largest change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(60000),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k],
+      change: 730120,
+      fee: 1880,
+    },
+  ],
+  [
+    'Small output, prefer largest UTXO with largest change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(5000),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k],
+      change: 785120,
+      fee: 1880,
+    },
+  ],
+  [
+    'Exact change output, prefer smaller UTXO with no change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(8170),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo10k],
+      change: 0,
+      fee: 1830,
+    },
+  ],
+  [
+    'Multiple inputs, prefer large change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(792000),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k, utxo384k],
+      change: 381220,
+      fee: 2780,
+    },
+  ],
+  [
+    'Exact change inputs, multiple UTXOs, prefer no change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(799570),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k, utxo10k],
+      change: 0,
+      fee: 2430,
+    },
+  ],
+  [
+    'All inputs, exclude dust',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(1184000),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k, utxo384k, utxo10k, utxo3k],
+      change: 0,
+      fee: 5000,
+    },
+  ],
+  [
+    'Multiple recipients, prefer large change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(20000),
+      },
+      {
+        address: recipientAddress2,
+        amountSats: new BigNumber(30000),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k],
+      change: 739690,
+      fee: 2310,
+    },
+  ],
+  [
+    'Multiple recipients, low value, prefer high change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(5000),
+      },
+      {
+        address: recipientAddress2,
+        amountSats: new BigNumber(1200),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo792k],
+      change: 783490,
+      fee: 2310,
+    },
+  ],
+  [
+    'Multiple recipients, exact value, prefer no change',
+    [
+      {
+        address: recipientAddress1,
+        amountSats: new BigNumber(5000),
+      },
+      {
+        address: recipientAddress2,
+        amountSats: new BigNumber(2900),
+      },
+    ],
+    10,
+    {
+      selectedUtxos: [utxo10k],
+      change: 0,
+      fee: 2100,
+    },
+  ],
+];

--- a/tests/transactions/btc.test.ts
+++ b/tests/transactions/btc.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import BigNumber from 'bignumber.js';
+import { selectUtxosForSend } from '../../transactions/btc';
+import { utxos } from './btc.data';
+import { recipientAddress1, selectUtxosForSendSuccessFixtures } from './btc.fixtures';
+
+const dummyChangeAddress = 'bc1pzsm9pu47e7npkvxh9dcd0dc2qwqshxt2a9tt7aq3xe9krpl8e82sx6phdj';
+
+describe('selectUtxosForSend', () => {
+  it.each(selectUtxosForSendSuccessFixtures)(
+    'should select utxos for send: %s',
+    (_testName, recipients, feeRate, expected) => {
+      const selectedUtxoData = selectUtxosForSend(dummyChangeAddress, recipients, utxos, feeRate);
+
+      expect(selectedUtxoData).toBeDefined();
+
+      const { feeRate: actualFeeRate, ...selectedWithoutFeeRate } = selectedUtxoData || {};
+      expect(selectedWithoutFeeRate).toEqual(expected);
+      expect(actualFeeRate).toBeGreaterThanOrEqual(feeRate);
+    },
+  );
+
+  it('should return undefined if no utxos', () => {
+    const selectedUtxoData = selectUtxosForSend(
+      dummyChangeAddress,
+      [{ address: recipientAddress1, amountSats: new BigNumber(1000) }],
+      [],
+      10,
+    );
+
+    expect(selectedUtxoData).toBeUndefined();
+  });
+
+  it('should return undefined if not enough value in utxos', () => {
+    const selectedUtxoData = selectUtxosForSend(
+      dummyChangeAddress,
+      [{ address: recipientAddress1, amountSats: new BigNumber(10000000) }],
+      utxos,
+      10,
+    );
+
+    expect(selectedUtxoData).toBeUndefined();
+  });
+
+  it('should throw if no recipients', () => {
+    expect(() => selectUtxosForSend(dummyChangeAddress, [], utxos, 10)).toThrow('Must have at least one recipient');
+  });
+
+  it('should throw if fee rate not a positive number', () => {
+    const recipients = [{ address: recipientAddress1, amountSats: new BigNumber(10000000) }];
+    expect(() => selectUtxosForSend(dummyChangeAddress, recipients, utxos, 0)).toThrow(
+      'Fee rate must be a positive number',
+    );
+    expect(() => selectUtxosForSend(dummyChangeAddress, recipients, utxos, -1)).toThrow(
+      'Fee rate must be a positive number',
+    );
+  });
+});

--- a/tests/transactions/btc.test.ts
+++ b/tests/transactions/btc.test.ts
@@ -10,7 +10,7 @@ const dummyChangeAddress = 'bc1pzsm9pu47e7npkvxh9dcd0dc2qwqshxt2a9tt7aq3xe9krpl8
 describe('selectUtxosForSend', () => {
   it.each(selectUtxosForSendSuccessFixtures)(
     'should select utxos for send: %s',
-    (_testName, recipients, feeRate, expected) => {
+    (_testName, { recipients, feeRate, expected }) => {
       const selectedUtxoData = selectUtxosForSend({
         changeAddress: dummyChangeAddress,
         recipients,

--- a/tests/transactions/btc.test.ts
+++ b/tests/transactions/btc.test.ts
@@ -11,7 +11,12 @@ describe('selectUtxosForSend', () => {
   it.each(selectUtxosForSendSuccessFixtures)(
     'should select utxos for send: %s',
     (_testName, recipients, feeRate, expected) => {
-      const selectedUtxoData = selectUtxosForSend(dummyChangeAddress, recipients, utxos, feeRate);
+      const selectedUtxoData = selectUtxosForSend({
+        changeAddress: dummyChangeAddress,
+        recipients,
+        availableUtxos: utxos,
+        feeRate,
+      });
 
       expect(selectedUtxoData).toBeDefined();
 
@@ -22,13 +27,13 @@ describe('selectUtxosForSend', () => {
   );
 
   it('should force select pinned UTXOs', () => {
-    const selectedUtxoData = selectUtxosForSend(
-      dummyChangeAddress,
-      [{ address: recipientAddress1, amountSats: new BigNumber(50000) }],
-      utxos,
-      10,
-      [utxo3k],
-    );
+    const selectedUtxoData = selectUtxosForSend({
+      changeAddress: dummyChangeAddress,
+      recipients: [{ address: recipientAddress1, amountSats: new BigNumber(50000) }],
+      availableUtxos: utxos,
+      feeRate: 10,
+      pinnedUtxos: [utxo3k],
+    });
 
     expect(selectedUtxoData).toEqual({
       selectedUtxos: [utxo3k, utxo792k],
@@ -39,38 +44,50 @@ describe('selectUtxosForSend', () => {
   });
 
   it('should return undefined if no utxos', () => {
-    const selectedUtxoData = selectUtxosForSend(
-      dummyChangeAddress,
-      [{ address: recipientAddress1, amountSats: new BigNumber(1000) }],
-      [],
-      10,
-    );
+    const selectedUtxoData = selectUtxosForSend({
+      changeAddress: dummyChangeAddress,
+      recipients: [{ address: recipientAddress1, amountSats: new BigNumber(1000) }],
+      availableUtxos: [],
+      feeRate: 10,
+    });
 
     expect(selectedUtxoData).toBeUndefined();
   });
 
   it('should return undefined if not enough value in utxos', () => {
-    const selectedUtxoData = selectUtxosForSend(
-      dummyChangeAddress,
-      [{ address: recipientAddress1, amountSats: new BigNumber(10000000) }],
-      utxos,
-      10,
-    );
+    const selectedUtxoData = selectUtxosForSend({
+      changeAddress: dummyChangeAddress,
+      recipients: [{ address: recipientAddress1, amountSats: new BigNumber(10000000) }],
+      availableUtxos: utxos,
+      feeRate: 10,
+    });
 
     expect(selectedUtxoData).toBeUndefined();
   });
 
   it('should throw if no recipients', () => {
-    expect(() => selectUtxosForSend(dummyChangeAddress, [], utxos, 10)).toThrow('Must have at least one recipient');
+    expect(() =>
+      selectUtxosForSend({ changeAddress: dummyChangeAddress, recipients: [], availableUtxos: utxos, feeRate: 10 }),
+    ).toThrow('Must have at least one recipient');
   });
 
   it('should throw if fee rate not a positive number', () => {
     const recipients = [{ address: recipientAddress1, amountSats: new BigNumber(10000000) }];
-    expect(() => selectUtxosForSend(dummyChangeAddress, recipients, utxos, 0)).toThrow(
-      'Fee rate must be a positive number',
-    );
-    expect(() => selectUtxosForSend(dummyChangeAddress, recipients, utxos, -1)).toThrow(
-      'Fee rate must be a positive number',
-    );
+    expect(() =>
+      selectUtxosForSend({
+        changeAddress: dummyChangeAddress,
+        recipients: recipients,
+        availableUtxos: utxos,
+        feeRate: 0,
+      }),
+    ).toThrow('Fee rate must be a positive number');
+    expect(() =>
+      selectUtxosForSend({
+        changeAddress: dummyChangeAddress,
+        recipients: recipients,
+        availableUtxos: utxos,
+        feeRate: -1,
+      }),
+    ).toThrow('Fee rate must be a positive number');
   });
 });

--- a/tests/transactions/btc.test.ts
+++ b/tests/transactions/btc.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import BigNumber from 'bignumber.js';
 import { selectUtxosForSend } from '../../transactions/btc';
-import { utxos } from './btc.data';
+import { utxo3k, utxo792k, utxos } from './btc.data';
 import { recipientAddress1, selectUtxosForSendSuccessFixtures } from './btc.fixtures';
 
 const dummyChangeAddress = 'bc1pzsm9pu47e7npkvxh9dcd0dc2qwqshxt2a9tt7aq3xe9krpl8e82sx6phdj';
@@ -20,6 +20,23 @@ describe('selectUtxosForSend', () => {
       expect(actualFeeRate).toBeGreaterThanOrEqual(feeRate);
     },
   );
+
+  it('should force select pinned UTXOs', () => {
+    const selectedUtxoData = selectUtxosForSend(
+      dummyChangeAddress,
+      [{ address: recipientAddress1, amountSats: new BigNumber(50000) }],
+      utxos,
+      10,
+      [utxo3k],
+    );
+
+    expect(selectedUtxoData).toEqual({
+      selectedUtxos: [utxo3k, utxo792k],
+      change: 742210,
+      fee: 2790,
+      feeRate: 10,
+    });
+  });
 
   it('should return undefined if no utxos', () => {
     const selectedUtxoData = selectUtxosForSend(

--- a/tests/transactions/btc.util.test.ts
+++ b/tests/transactions/btc.util.test.ts
@@ -1,0 +1,252 @@
+import BigNumber from 'bignumber.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { utxo10k, utxo384k, utxo3k, utxo792k } from './btc.data';
+
+import * as self from '../../transactions/btc.utils';
+
+const dummyChangeAddress = 'bc1pzsm9pu47e7npkvxh9dcd0dc2qwqshxt2a9tt7aq3xe9krpl8e82sx6phdj';
+
+describe('selectOptimalUtxos', () => {
+  it('should return immediately if inputs result in valid metadata', () => {
+    const mockedResponse = {
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [],
+    };
+    const getMetadataMock = vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(mockedResponse);
+
+    const result = self.selectOptimalUtxos({
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [utxo10k],
+      availableUtxos: [],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    });
+
+    expect(result).toEqual(mockedResponse);
+    expect(getMetadataMock).toHaveBeenCalledOnce();
+  });
+
+  it('should return undefined if there are no available UTXOs', () => {
+    const getMetadataMock = vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+
+    const result = self.selectOptimalUtxos({
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    });
+
+    expect(result).toBe(undefined);
+    expect(getMetadataMock).toHaveBeenCalledOnce();
+  });
+
+  it('should return undefined if we would be selecting more UTXOs than current best + 1', () => {
+    const getMetadataMock = vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+
+    const result = self.selectOptimalUtxos({
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [utxo10k, utxo384k],
+      availableUtxos: [utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+      currentBestUtxoCount: 1,
+    });
+
+    expect(result).toBe(undefined);
+    expect(getMetadataMock).toHaveBeenCalledOnce();
+  });
+
+  it('tries highest value UTXO first and returns undefined if metadata is undefined', async () => {
+    const selectOptimalUtxos = self.selectOptimalUtxos;
+    vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+    const selectOptimalUtxosMock = vi.spyOn(self, 'selectOptimalUtxos').mockReturnValueOnce(undefined);
+
+    const props = {
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [utxo10k, utxo384k, utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    };
+
+    const result = selectOptimalUtxos(props);
+
+    expect(result).toBe(undefined);
+    expect(selectOptimalUtxosMock).toHaveBeenCalledTimes(1);
+    expect(selectOptimalUtxosMock).toHaveBeenCalledWith({
+      recipients: props.recipients,
+      selectedUtxos: [utxo792k],
+      availableUtxos: [utxo3k, utxo10k, utxo384k],
+      changeAddress: props.changeAddress,
+      feeRate: props.feeRate,
+      currentBestUtxoCount: undefined,
+    });
+  });
+
+  it('tries UTXOs in decreasing order of value and returns highest value if fees are same', async () => {
+    const selectOptimalUtxos = self.selectOptimalUtxos;
+    vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+    const selectOptimalUtxosMock = vi.spyOn(self, 'selectOptimalUtxos').mockImplementation(({ selectedUtxos }) => ({
+      fee: 10,
+      change: selectedUtxos[0].value,
+      feeRate: 1,
+      selectedUtxos,
+    }));
+
+    const props = {
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [utxo10k, utxo384k, utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    };
+
+    const result = selectOptimalUtxos(props);
+
+    expect(result).toEqual({
+      fee: 10,
+      change: utxo792k.value,
+      feeRate: 1,
+      selectedUtxos: [utxo792k],
+    });
+    // expect to have been called once per UTXO
+    expect(selectOptimalUtxosMock).toHaveBeenCalledTimes(4);
+    expect(selectOptimalUtxosMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ selectedUtxos: [utxo792k] }));
+    expect(selectOptimalUtxosMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ selectedUtxos: [utxo384k] }));
+    expect(selectOptimalUtxosMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ selectedUtxos: [utxo10k] }));
+    expect(selectOptimalUtxosMock).toHaveBeenNthCalledWith(4, expect.objectContaining({ selectedUtxos: [utxo3k] }));
+  });
+
+  it('tries UTXOs until fee increases then returns', async () => {
+    const selectOptimalUtxos = self.selectOptimalUtxos;
+    vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+    const selectOptimalUtxosMock = vi.spyOn(self, 'selectOptimalUtxos');
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo792k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 50,
+      feeRate: 1,
+      selectedUtxos: [utxo384k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 11,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo10k],
+    });
+
+    const props = {
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [utxo10k, utxo384k, utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    };
+
+    const result = selectOptimalUtxos(props);
+
+    expect(result).toEqual({
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo792k],
+    });
+    // expect to have been called once per UTXO
+    expect(selectOptimalUtxosMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('prefers UTXO selection with lower fee, even if change is lower', async () => {
+    const selectOptimalUtxos = self.selectOptimalUtxos;
+    vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+    const selectOptimalUtxosMock = vi.spyOn(self, 'selectOptimalUtxos');
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo792k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 9,
+      change: 50,
+      feeRate: 1,
+      selectedUtxos: [utxo384k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo10k],
+    });
+
+    const props = {
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [utxo10k, utxo384k, utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    };
+
+    const result = selectOptimalUtxos(props);
+
+    expect(result).toEqual({
+      fee: 9,
+      change: 50,
+      feeRate: 1,
+      selectedUtxos: [utxo384k],
+    });
+    // expect to have been called once per UTXO
+    expect(selectOptimalUtxosMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('prefers UTXO selections with higher change if fees are same', async () => {
+    const selectOptimalUtxos = self.selectOptimalUtxos;
+    vi.spyOn(self, 'getTransactionMetadataForUtxos').mockReturnValueOnce(undefined);
+    const selectOptimalUtxosMock = vi.spyOn(self, 'selectOptimalUtxos');
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo792k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 10,
+      change: 150,
+      feeRate: 1,
+      selectedUtxos: [utxo384k],
+    });
+    selectOptimalUtxosMock.mockReturnValueOnce({
+      fee: 11,
+      change: 100,
+      feeRate: 1,
+      selectedUtxos: [utxo10k],
+    });
+
+    const props = {
+      recipients: [{ address: '', amountSats: new BigNumber(10) }],
+      selectedUtxos: [],
+      availableUtxos: [utxo10k, utxo384k, utxo792k, utxo3k],
+      changeAddress: dummyChangeAddress,
+      feeRate: 1,
+    };
+
+    const result = selectOptimalUtxos(props);
+
+    expect(result).toEqual({
+      fee: 10,
+      change: 150,
+      feeRate: 1,
+      selectedUtxos: [utxo384k],
+    });
+    // expect to have been called once per UTXO
+    expect(selectOptimalUtxosMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -1,14 +1,14 @@
 // import { payments, networks, Psbt, Payment, Transaction } from 'bitcoinjs-lib';
 // import { ECPairFactory } from 'ecpair';
-import BigNumber from 'bignumber.js';
-import { ErrorCodes, NetworkType, ResponseError, BtcFeeResponse, UTXO } from '../types';
-import { fetchBtcFeeRate } from '../api/xverse';
-import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
-import * as btc from '@scure/btc-signer';
-import { hex } from '@scure/base';
 import * as secp256k1 from '@noble/secp256k1';
-import { BitcoinNetwork, getBtcNetwork } from './btcNetwork';
+import { hex } from '@scure/base';
+import * as btc from '@scure/btc-signer';
+import BigNumber from 'bignumber.js';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import { fetchBtcFeeRate } from '../api/xverse';
+import { BtcFeeResponse, ErrorCodes, NetworkType, ResponseError, UTXO } from '../types';
+import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
+import { BitcoinNetwork, getBtcNetwork } from './btcNetwork';
 
 const MINIMUM_CHANGE_OUTPUT_SATS = 1000;
 
@@ -476,6 +476,7 @@ export function createTransaction(
   recipients: Array<Recipient>,
   changeAddress: string,
   network: NetworkType,
+  skipChange = false,
 ): btc.Transaction {
   // Create Bitcoin transaction
   const tx = new btc.Transaction();
@@ -501,11 +502,202 @@ export function createTransaction(
   });
 
   // Add change output
-  if (changeSats.gt(new BigNumber(MINIMUM_CHANGE_OUTPUT_SATS))) {
+  if (!skipChange && changeSats.gt(new BigNumber(MINIMUM_CHANGE_OUTPUT_SATS))) {
     addOutput(tx, changeAddress, changeSats, btcNetwork);
   }
 
   return tx;
+}
+
+function getTransactionMetadataForUtxos(
+  recipients: Recipient[],
+  selectedUtxos: UTXO[],
+  changeAddress: string,
+  feeRate: number,
+): TransactionUtxoSelectionMetadata | undefined {
+  const dummyPrivateKey = '0000000000000000000000000000000000000000000000000000000000000001';
+
+  const inputSum = selectedUtxos.reduce<BigNumber>((sum, utxo) => sum.plus(utxo.value), new BigNumber(0));
+  const recipientTotal = recipients.reduce<BigNumber>(
+    (sum, recipient) => sum.plus(recipient.amountSats),
+    new BigNumber(0),
+  );
+
+  // these are conservative estimates
+  const ESTIMATED_VBYTES_PER_OUTPUT = 45; // actually around 50
+  const ESTIMATED_VBYTES_PER_INPUT = 85; // actually around 89 or 90
+  const BITCOIN_DUST_VALUE = 1000;
+
+  const estimatedFees = new BigNumber(feeRate).times(
+    ESTIMATED_VBYTES_PER_OUTPUT * recipients.length + ESTIMATED_VBYTES_PER_INPUT * selectedUtxos.length,
+  );
+  // ensure that the UTXOs can cover the expected outputs
+  if (!inputSum.gt(recipientTotal.plus(estimatedFees))) return undefined;
+
+  {
+    // try transaction with change
+    const tx = createTransaction(dummyPrivateKey, selectedUtxos, recipientTotal, recipients, changeAddress, 'Mainnet');
+
+    tx.sign(hex.decode(dummyPrivateKey));
+    tx.finalize();
+
+    const txSize = tx.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < tx.outputsLength; i++) {
+      const output = tx.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const change = sentSats.minus(recipientTotal);
+    const fee = new BigNumber(txSize).times(feeRate);
+
+    // check if there is change and if the change is greater than the vsize*feeRate + dust rate
+    if (change.gt(fee.plus(BITCOIN_DUST_VALUE))) {
+      const changeWithoutFee = change.minus(fee);
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: feeRate,
+        change: changeWithoutFee.toNumber(),
+      };
+    }
+  }
+
+  {
+    // try txn without change
+    const txNoChange = createTransaction(
+      dummyPrivateKey,
+      selectedUtxos,
+      recipientTotal,
+      recipients,
+      changeAddress,
+      'Mainnet',
+      true,
+    );
+
+    txNoChange.sign(hex.decode(dummyPrivateKey));
+    txNoChange.finalize();
+
+    const txSize = txNoChange.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < txNoChange.outputsLength; i++) {
+      const output = txNoChange.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const fee = inputSum.minus(sentSats);
+
+    if (fee.div(txSize).gt(feeRate)) {
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: fee.div(txSize).toNumber(),
+        change: 0,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function selectOptimalUtxos(
+  recipients: Recipient[],
+  selectedUtxos: UTXO[],
+  availableUtxos: UTXO[],
+  changeAddress: string,
+  feeRate: number,
+  currentBestUtxoCount: number | undefined = undefined,
+): TransactionUtxoSelectionMetadata | undefined {
+  const currentSelectionData = getTransactionMetadataForUtxos(recipients, selectedUtxos, changeAddress, feeRate);
+
+  // if there is a valid selection, adding more UTXOs would only make the fees higher, so just return
+  if (currentSelectionData) return currentSelectionData;
+
+  if (availableUtxos.length === 0 || currentBestUtxoCount === selectedUtxos.length - 1) {
+    // we either have no more UTXOs to add or adding would make an existing outer selection worse, so we bail
+    return undefined;
+  }
+
+  // sort smallest to biggest so we can pop biggest from end
+  const sortedUtxos = [...availableUtxos];
+  sortedUtxos.sort((a, b) => a.value - b.value);
+
+  let bestSelectionData: TransactionUtxoSelectionMetadata | undefined = undefined;
+  while (sortedUtxos.length > 0) {
+    const utxo = sortedUtxos.pop() as UTXO;
+
+    const nextSelectionData = selectOptimalUtxos(
+      recipients,
+      [...selectedUtxos, utxo],
+      sortedUtxos,
+      changeAddress,
+      feeRate,
+      currentBestUtxoCount ?? bestSelectionData?.selectedUtxos.length,
+    );
+
+    if (!nextSelectionData) return bestSelectionData;
+
+    /**
+     * we want to:
+     * - minimise fees
+     * - have zero change or maximise change
+     * - while staying above the selected fee rate
+     **/
+    if (!bestSelectionData) {
+      bestSelectionData = nextSelectionData;
+    } else if (bestSelectionData.fee > nextSelectionData.fee) {
+      bestSelectionData = nextSelectionData;
+    } else if (nextSelectionData.fee === bestSelectionData.fee) {
+      if (bestSelectionData.change < nextSelectionData.change) {
+        bestSelectionData = nextSelectionData;
+      }
+    } else {
+      return bestSelectionData;
+    }
+  }
+
+  return bestSelectionData;
+}
+
+type TransactionUtxoSelectionMetadata = {
+  selectedUtxos: UTXO[];
+  fee: number;
+  feeRate: number;
+  change: number;
+};
+
+/**
+ * Finds the optimal combination of UTXOs to send the given amount to the given recipients while minimizing fees,
+ * yet staying above the desired fee rate.
+ */
+export function selectUtxosForSend(
+  changeAddress: string,
+  recipients: Recipient[],
+  availableUtxos: UTXO[],
+  feeRate: number,
+  pinnedUtxos: UTXO[] = [],
+): TransactionUtxoSelectionMetadata | undefined {
+  if (recipients.length === 0) {
+    throw new Error('Must have at least one recipient');
+  }
+
+  if (feeRate <= 0) {
+    throw new Error('Fee rate must be a positive number');
+  }
+
+  const pinnedLocations = new Set(pinnedUtxos.map((utxo) => `${utxo.txid}:${utxo.vout}`));
+
+  const sortedUtxos = availableUtxos.filter((utxo) => {
+    const utxoLocation = `${utxo.txid}:${utxo.vout}`;
+    return !pinnedLocations.has(utxoLocation);
+  });
+  sortedUtxos.sort((a, b) => a.value - b.value);
+
+  const selectedUtxoData = selectOptimalUtxos(recipients, pinnedUtxos, sortedUtxos, changeAddress, feeRate);
+
+  return selectedUtxoData;
 }
 
 export function createOrdinalTransaction(

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -656,6 +656,7 @@ function selectOptimalUtxos({
 
   let bestSelectionData: TransactionUtxoSelectionMetadata | undefined;
   while (sortedUtxos.length > 0) {
+    // We know at this point that the sortedUtxos array has a value, so we can safely pop and type to a UTXO
     const utxo = sortedUtxos.pop() as UTXO;
 
     const nextSelectionData = selectOptimalUtxos({

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -615,7 +615,11 @@ function selectOptimalUtxos(
   // if there is a valid selection, adding more UTXOs would only make the fees higher, so just return
   if (currentSelectionData) return currentSelectionData;
 
-  if (availableUtxos.length === 0 || currentBestUtxoCount === selectedUtxos.length - 1) {
+  // if we have a current best selection, we want to check if adding another UTXO would make the fees higher
+  // and skip if it does since it would be a worse selection
+  const wouldIncreaseFees = currentBestUtxoCount === selectedUtxos.length - 1;
+
+  if (availableUtxos.length === 0 || wouldIncreaseFees) {
     // we either have no more UTXOs to add or adding would make an existing outer selection worse, so we bail
     return undefined;
   }

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -8,6 +8,7 @@ import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import { fetchBtcFeeRate } from '../api/xverse';
 import { BtcFeeResponse, ErrorCodes, NetworkType, ResponseError, UTXO } from '../types';
 import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
+import { selectOptimalUtxos } from './btc.utils';
 import { BitcoinNetwork, getBtcNetwork } from './btcNetwork';
 
 const MINIMUM_CHANGE_OUTPUT_SATS = 1000;
@@ -527,172 +528,7 @@ export async function getBtcFeesForNonOrdinalBtcSend(
   }
 }
 
-function getTransactionMetadataForUtxos(
-  recipients: Recipient[],
-  selectedUtxos: UTXO[],
-  changeAddress: string,
-  feeRate: number,
-): TransactionUtxoSelectionMetadata | undefined {
-  const dummyPrivateKey = '0000000000000000000000000000000000000000000000000000000000000001';
-
-  const inputSum = selectedUtxos.reduce<BigNumber>((sum, utxo) => sum.plus(utxo.value), new BigNumber(0));
-  const recipientTotal = recipients.reduce<BigNumber>(
-    (sum, recipient) => sum.plus(recipient.amountSats),
-    new BigNumber(0),
-  );
-
-  // these are conservative estimates
-  const ESTIMATED_VBYTES_PER_OUTPUT = 45; // actually around 50
-  const ESTIMATED_VBYTES_PER_INPUT = 85; // actually around 89 or 90
-  const BITCOIN_DUST_VALUE = 1000;
-
-  const estimatedFees = new BigNumber(feeRate).times(
-    ESTIMATED_VBYTES_PER_OUTPUT * recipients.length + ESTIMATED_VBYTES_PER_INPUT * selectedUtxos.length,
-  );
-  // ensure that the UTXOs can cover the expected outputs
-  if (!inputSum.gt(recipientTotal.plus(estimatedFees))) return undefined;
-
-  {
-    // try transaction with change
-    const tx = createTransaction(dummyPrivateKey, selectedUtxos, recipientTotal, recipients, changeAddress, 'Mainnet');
-
-    tx.sign(hex.decode(dummyPrivateKey));
-    tx.finalize();
-
-    const txSize = tx.vsize;
-    let sentSats = new BigNumber(0);
-
-    for (let i = 0; i < tx.outputsLength; i++) {
-      const output = tx.getOutput(i);
-      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
-    }
-
-    const change = sentSats.minus(recipientTotal);
-    const fee = new BigNumber(txSize).times(feeRate);
-
-    // check if there is change and if the change is greater than the vsize*feeRate + dust rate
-    if (change.gt(fee.plus(BITCOIN_DUST_VALUE))) {
-      const changeWithoutFee = change.minus(fee);
-      return {
-        selectedUtxos,
-        fee: fee.toNumber(),
-        feeRate: feeRate,
-        change: changeWithoutFee.toNumber(),
-      };
-    }
-  }
-
-  {
-    // try txn without change
-    const txNoChange = createTransaction(
-      dummyPrivateKey,
-      selectedUtxos,
-      recipientTotal,
-      recipients,
-      changeAddress,
-      'Mainnet',
-      true,
-    );
-
-    txNoChange.sign(hex.decode(dummyPrivateKey));
-    txNoChange.finalize();
-
-    const txSize = txNoChange.vsize;
-    let sentSats = new BigNumber(0);
-
-    for (let i = 0; i < txNoChange.outputsLength; i++) {
-      const output = txNoChange.getOutput(i);
-      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
-    }
-
-    const fee = inputSum.minus(sentSats);
-
-    if (fee.div(txSize).gt(feeRate)) {
-      return {
-        selectedUtxos,
-        fee: fee.toNumber(),
-        feeRate: fee.div(txSize).toNumber(),
-        change: 0,
-      };
-    }
-  }
-
-  return undefined;
-}
-
-type SelectOptimalUtxosProps = {
-  recipients: Recipient[];
-  selectedUtxos: UTXO[];
-  availableUtxos: UTXO[];
-  changeAddress: string;
-  feeRate: number;
-  currentBestUtxoCount?: number;
-};
-function selectOptimalUtxos({
-  recipients,
-  selectedUtxos,
-  availableUtxos,
-  changeAddress,
-  feeRate,
-  currentBestUtxoCount,
-}: SelectOptimalUtxosProps): TransactionUtxoSelectionMetadata | undefined {
-  const currentSelectionData = getTransactionMetadataForUtxos(recipients, selectedUtxos, changeAddress, feeRate);
-
-  // if there is a valid selection, adding more UTXOs would only make the fees higher, so just return
-  if (currentSelectionData) return currentSelectionData;
-
-  // if we have a current best selection, we want to check if adding another UTXO would make the fees higher
-  // and skip if it does since it would be a worse selection
-  const wouldIncreaseFees = currentBestUtxoCount === selectedUtxos.length - 1;
-
-  if (availableUtxos.length === 0 || wouldIncreaseFees) {
-    // we either have no more UTXOs to add or adding would make an existing outer selection worse, so we bail
-    return undefined;
-  }
-
-  // sort smallest to biggest so we can pop biggest from end
-  const sortedUtxos = [...availableUtxos];
-  sortedUtxos.sort((a, b) => a.value - b.value);
-
-  let bestSelectionData: TransactionUtxoSelectionMetadata | undefined;
-  while (sortedUtxos.length > 0) {
-    // We know at this point that the sortedUtxos array has a value, so we can safely pop and type to a UTXO
-    const utxo = sortedUtxos.pop() as UTXO;
-
-    const nextSelectionData = selectOptimalUtxos({
-      recipients,
-      selectedUtxos: [...selectedUtxos, utxo],
-      availableUtxos: sortedUtxos,
-      changeAddress,
-      feeRate,
-      currentBestUtxoCount: currentBestUtxoCount ?? bestSelectionData?.selectedUtxos.length,
-    });
-
-    if (!nextSelectionData) return bestSelectionData;
-
-    /**
-     * we want to:
-     * - minimise fees
-     * - have zero change or maximise change
-     * - while staying above the selected fee rate
-     **/
-    if (!bestSelectionData) {
-      bestSelectionData = nextSelectionData;
-    } else if (bestSelectionData.fee > nextSelectionData.fee) {
-      bestSelectionData = nextSelectionData;
-    } else if (nextSelectionData.fee === bestSelectionData.fee) {
-      if (bestSelectionData.change < nextSelectionData.change) {
-        bestSelectionData = nextSelectionData;
-      }
-    } else {
-      return bestSelectionData;
-    }
-  }
-
-  return bestSelectionData;
-}
-
-type SelectUtxosForSendProps = {
+export type SelectUtxosForSendProps = {
   changeAddress: string;
   recipients: Recipient[];
   availableUtxos: UTXO[];
@@ -700,12 +536,13 @@ type SelectUtxosForSendProps = {
   pinnedUtxos?: UTXO[];
 };
 
-type TransactionUtxoSelectionMetadata = {
+export type TransactionUtxoSelectionMetadata = {
   selectedUtxos: UTXO[];
   fee: number;
   feeRate: number;
   change: number;
 };
+
 /**
  * Finds the optimal combination of UTXOs to send the given amount to the given recipients while minimizing fees,
  * yet staying above the desired fee rate.

--- a/transactions/btc.utils.ts
+++ b/transactions/btc.utils.ts
@@ -1,0 +1,170 @@
+import { hex } from '@scure/base';
+import BigNumber from 'bignumber.js';
+import { UTXO } from '../types';
+import type { Recipient, TransactionUtxoSelectionMetadata } from './btc';
+import { createTransaction } from './btc';
+
+export function getTransactionMetadataForUtxos(
+  recipients: Recipient[],
+  selectedUtxos: UTXO[],
+  changeAddress: string,
+  feeRate: number,
+): TransactionUtxoSelectionMetadata | undefined {
+  const dummyPrivateKey = '0000000000000000000000000000000000000000000000000000000000000001';
+
+  const inputSum = selectedUtxos.reduce<BigNumber>((sum, utxo) => sum.plus(utxo.value), new BigNumber(0));
+  const recipientTotal = recipients.reduce<BigNumber>(
+    (sum, recipient) => sum.plus(recipient.amountSats),
+    new BigNumber(0),
+  );
+
+  // these are conservative estimates
+  const ESTIMATED_VBYTES_PER_OUTPUT = 45; // actually around 50
+  const ESTIMATED_VBYTES_PER_INPUT = 85; // actually around 89 or 90
+  const BITCOIN_DUST_VALUE = 1000;
+
+  const estimatedFees = new BigNumber(feeRate).times(
+    ESTIMATED_VBYTES_PER_OUTPUT * recipients.length + ESTIMATED_VBYTES_PER_INPUT * selectedUtxos.length,
+  );
+  // ensure that the UTXOs can cover the expected outputs
+  if (!inputSum.gt(recipientTotal.plus(estimatedFees))) return undefined;
+
+  {
+    // try transaction with change
+    const tx = createTransaction(dummyPrivateKey, selectedUtxos, recipientTotal, recipients, changeAddress, 'Mainnet');
+
+    tx.sign(hex.decode(dummyPrivateKey));
+    tx.finalize();
+
+    const txSize = tx.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < tx.outputsLength; i++) {
+      const output = tx.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const change = sentSats.minus(recipientTotal);
+    const fee = new BigNumber(txSize).times(feeRate);
+
+    // check if there is change and if the change is greater than the vsize*feeRate + dust rate
+    if (change.gt(fee.plus(BITCOIN_DUST_VALUE))) {
+      const changeWithoutFee = change.minus(fee);
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: feeRate,
+        change: changeWithoutFee.toNumber(),
+      };
+    }
+  }
+
+  {
+    // try txn without change
+    const txNoChange = createTransaction(
+      dummyPrivateKey,
+      selectedUtxos,
+      recipientTotal,
+      recipients,
+      changeAddress,
+      'Mainnet',
+      true,
+    );
+
+    txNoChange.sign(hex.decode(dummyPrivateKey));
+    txNoChange.finalize();
+
+    const txSize = txNoChange.vsize;
+    let sentSats = new BigNumber(0);
+
+    for (let i = 0; i < txNoChange.outputsLength; i++) {
+      const output = txNoChange.getOutput(i);
+      sentSats = sentSats.plus(new BigNumber((output.amount ?? 0n).toString()));
+    }
+
+    const fee = inputSum.minus(sentSats);
+
+    if (fee.div(txSize).gt(feeRate)) {
+      return {
+        selectedUtxos,
+        fee: fee.toNumber(),
+        feeRate: fee.div(txSize).toNumber(),
+        change: 0,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+type SelectOptimalUtxosProps = {
+  recipients: Recipient[];
+  selectedUtxos: UTXO[];
+  availableUtxos: UTXO[];
+  changeAddress: string;
+  feeRate: number;
+  currentBestUtxoCount?: number;
+};
+export function selectOptimalUtxos({
+  recipients,
+  selectedUtxos,
+  availableUtxos,
+  changeAddress,
+  feeRate,
+  currentBestUtxoCount,
+}: SelectOptimalUtxosProps): TransactionUtxoSelectionMetadata | undefined {
+  const currentSelectionData = getTransactionMetadataForUtxos(recipients, selectedUtxos, changeAddress, feeRate);
+
+  // if there is a valid selection, adding more UTXOs would only make the fees higher, so just return
+  if (currentSelectionData) return currentSelectionData;
+
+  // if we have a current best selection, we want to check if adding another UTXO would make the fees higher
+  // and skip if it does since it would be a worse selection
+  const wouldIncreaseFees = currentBestUtxoCount === selectedUtxos.length - 1;
+
+  if (availableUtxos.length === 0 || wouldIncreaseFees) {
+    // we either have no more UTXOs to add or adding would make an existing outer selection worse, so we bail
+    return undefined;
+  }
+
+  // sort smallest to biggest so we can pop biggest from end
+  const sortedUtxos = [...availableUtxos];
+  sortedUtxos.sort((a, b) => a.value - b.value);
+
+  let bestSelectionData: TransactionUtxoSelectionMetadata | undefined;
+  while (sortedUtxos.length > 0) {
+    // We know at this point that the sortedUtxos array has a value, so we can safely pop and type to a UTXO
+    const utxo = sortedUtxos.pop() as UTXO;
+
+    const nextSelectionData = selectOptimalUtxos({
+      recipients,
+      selectedUtxos: [...selectedUtxos, utxo],
+      availableUtxos: sortedUtxos,
+      changeAddress,
+      feeRate,
+      currentBestUtxoCount: currentBestUtxoCount ?? bestSelectionData?.selectedUtxos.length,
+    });
+
+    if (!nextSelectionData) return bestSelectionData;
+
+    /**
+     * we want to:
+     * - minimise fees
+     * - have zero change or maximise change
+     * - while staying above the selected fee rate
+     **/
+    if (!bestSelectionData) {
+      bestSelectionData = nextSelectionData;
+    } else if (bestSelectionData.fee > nextSelectionData.fee) {
+      bestSelectionData = nextSelectionData;
+    } else if (nextSelectionData.fee === bestSelectionData.fee) {
+      if (bestSelectionData.change < nextSelectionData.change) {
+        bestSelectionData = nextSelectionData;
+      }
+    } else {
+      return bestSelectionData;
+    }
+  }
+
+  return bestSelectionData;
+}


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?
- [X] Enhancement

# Screenshot
Txn made using this logic with fee rate set to 12: https://mempool.space/tx/d008c4788cf50a43a59d4c9e81a6642570bc9081bb951496dac2e0b7490597e6
<img width="1047" alt="image" src="https://github.com/secretkeylabs/xverse-core/assets/3322667/729ed23b-c5b7-431a-b5a1-7653c8a476f1">

NOTE: The requested fee rate is slightly higher when using this for transactions from a taproot address as the resulting transaction is smaller. We can expand on this in the future if we use this for ordinal transfers or other transactions from the taproot address.

# 📜 Background
Currently, we naively select which UTXOs to use for a transaction by picking UTXOs from a list ordered by block time (oldest to newest). This does not always end up with the most efficient transaction in terms of fees and best UTXO use. There is also an issue in how we calculate fees with the UTXO selection in that we add a change output during the calculation and UTXO selection, but the final transaction may not end up with enough SATS for change after the fees, so we end up with a transaction with 1 less output and, therefore, higher fees/fee rate.

The proposed solution is to create an algorithm which attempts to find the best UTXOs for a transaction by minimising the fees, while keeping the fee rate above the desired fee rate, while also either maximising the change or aiming for a zero change combination of UTXOs.

This means that the following are the desired outcomes (1 being more favourable), while keeping the fee at a minimum:
1. Having one or more input UTXOs which match the recipient sum+fees, as close as possible. This may result in a slightly higher fee rate than desired but would eliminate the change output (decreasing fees even though having a higher fee rate) and avoiding dust UTXOs.
2. Having the least number of inputs resulting in the biggest change output. This would use up UTXOs efficiently, while also ensuring that future transactions have a new UTXO with the highest value possible for more efficient future spend.

Issue Link: ENG-2497

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [X] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- Add a new function to select UTXOs for a transaction

Impact:
- This adds an improved way to select UTXOs for a transaction
- This method is currently unused in the extension and mobile app, so nothing to test yet

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
