### PR TITLE
1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
# 🔘 PR Type
- [x] Other... Please describe: Release

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- support outputscript https://github.com/secretkeylabs/xverse-core/pull/194 
- add xord and fallback to hiro when required https://github.com/secretkeylabs/xverse-core/pull/187 
- get Tx by tx_id https://github.com/secretkeylabs/xverse-core/pull/189 
- fix valid brc20 transfer logic https://github.com/secretkeylabs/xverse-core/pull/193 
- fix linting issue and enable ci https://github.com/secretkeylabs/xverse-core/pull/176 
