### PR TITLE
Add `deviceAccountIndex` field for `Account` interface

### DIFF
--- a/types/account.ts
+++ b/types/account.ts
@@ -12,4 +12,5 @@ export interface Account {
   bnsName?: string;
   accountType?: AccountType;
   accountName?: string;
+  deviceAccountIndex?: number;
 }


### PR DESCRIPTION
# 🔘 PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement


# 📜 Background
This PR is related to https://github.com/secretkeylabs/xverse-web-extension/pull/524 as it introduces the new field `deviceAccountIndex` for `Account` interface

Issue Link: https://linear.app/xverseapp/issue/ENG-2343/add-ability-to-remove-connected-ledger-account
Context Link (if applicable):

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- Added `deviceAccountIndex` field for `Account` interface

Impact:
- How it improves performance, fixes bugs, adds functionality, etc.
- Impact on downstream apps, link to issues or PRs for migration
- What to test

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
