### PR TITLE
Ordinal transaction functions

### DIFF
--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -486,6 +486,8 @@ export async function getBtcFeesForOrdinalTransaction(
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
   if (!ordUtxo) {
+    // TODO: Throw error and not just the code
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
   }
   return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo!, btcAddress, network, addressUtxos, feeMode, feeRateInput);
@@ -829,6 +831,8 @@ export async function signOrdinalTransaction(
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
   if (!ordUtxo) {
+    // TODO: Throw error and not just the code
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
   }
   return signOrdinalSendTransaction(

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -404,27 +404,6 @@ export function filterUtxos(allUtxos: UTXO[], filterUtxoSet: UTXO[]) {
     (utxo) => !filterUtxoSet.some((filterUtxo) => utxo.txid === filterUtxo.txid && utxo.vout === filterUtxo.vout),
   );
 }
-export async function getBtcFeesForOrdinalTransaction(
-  recipientAddress: string,
-  btcAddress: string,
-  ordinalsAddress: string,
-  network: NetworkType,
-  ordinal: Inscription,
-  isRecover?: boolean,
-  feeMode?: string,
-  feeRateInput?: string,
-) {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const address = isRecover ? btcAddress : ordinalsAddress;
-  const addressUtxos = await btcClient.getUnspentUtxos(address);
-  const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
-  if (!ordUtxo) {
-    throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
-  }
-  return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo!, btcAddress, network, addressUtxos, feeMode, feeRateInput);
-}
 
 // Used to calculate fees for setting low/high fee settings
 // Should replace this function
@@ -488,6 +467,28 @@ export async function getBtcFeesForOrdinalSend(
   } catch (error) {
     return Promise.reject(error.toString());
   }
+}
+
+export async function getBtcFeesForOrdinalTransaction(
+  recipientAddress: string,
+  btcAddress: string,
+  ordinalsAddress: string,
+  network: NetworkType,
+  ordinal: Inscription,
+  isRecover?: boolean,
+  feeMode?: string,
+  feeRateInput?: string,
+) {
+  const btcClient = new BitcoinEsploraApiProvider({
+    network,
+  });
+  const address = isRecover ? btcAddress : ordinalsAddress;
+  const addressUtxos = await btcClient.getUnspentUtxos(address);
+  const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
+  if (!ordUtxo) {
+    throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
+  }
+  return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo!, btcAddress, network, addressUtxos, feeMode, feeRateInput);
 }
 
 // Used to calculate fees for setting low/high fee settings
@@ -683,38 +684,6 @@ export async function signBtcTransaction(
   }
 }
 
-export async function signOrdinalTransaction(
-  recipientAddress: string,
-  btcAddress: string,
-  ordinalsAddress: string,
-  accountIndex: number,
-  seedPhrase: string,
-  network: NetworkType,
-  ordinal: Inscription,
-  fee?: BigNumber,
-  isRecover?: boolean,
-): Promise<SignedBtcTx> {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const address = isRecover ? btcAddress : ordinalsAddress;
-  const addressUtxos = await btcClient.getUnspentUtxos(address);
-  const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
-  if (!ordUtxo) {
-    throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
-  }
-  return signOrdinalSendTransaction(
-    recipientAddress,
-    ordUtxo,
-    btcAddress,
-    accountIndex,
-    seedPhrase,
-    network,
-    addressUtxos,
-    fee,
-  );
-}
-
 export async function signOrdinalSendTransaction(
   recipientAddress: string,
   ordinalUtxo: UTXO,
@@ -840,6 +809,38 @@ export async function signOrdinalSendTransaction(
   };
 
   return signedBtcTx;
+}
+
+export async function signOrdinalTransaction(
+  recipientAddress: string,
+  btcAddress: string,
+  ordinalsAddress: string,
+  accountIndex: number,
+  seedPhrase: string,
+  network: NetworkType,
+  ordinal: Inscription,
+  fee?: BigNumber,
+  isRecover?: boolean,
+): Promise<SignedBtcTx> {
+  const btcClient = new BitcoinEsploraApiProvider({
+    network,
+  });
+  const address = isRecover ? btcAddress : ordinalsAddress;
+  const addressUtxos = await btcClient.getUnspentUtxos(address);
+  const ordUtxo = addressUtxos.find((utx) => `${utx.txid}:${utx.vout}` === ordinal.output);
+  if (!ordUtxo) {
+    throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
+  }
+  return signOrdinalSendTransaction(
+    recipientAddress,
+    ordUtxo,
+    btcAddress,
+    accountIndex,
+    seedPhrase,
+    network,
+    addressUtxos,
+    fee,
+  );
 }
 
 export async function signNonOrdinalBtcSendTransaction(


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
We needed to move all the ordinals transactions logic to xverse-core. Including fetching and address UTXOs and getting the correct UTXO to send. 

Issue Link: https://linear.app/xverseapp/issue/ENG-2528/move-ordinal-transactions-logic-to-xverse-core
Context Link (if applicable):

# 🔄 Changes
I have created new functions to wrap up the existing ones. I passed the ordinal inscription and `isRecover` boolean. and function fetches the addressUtxos from ordinalAddress and from btcAddress if it's a recover transaction. 

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- modified transactions/btc.ts file to add new functions for getting fees for ordinal send transactions and signing ordinal transactions. 

Impact:
- This will help keep the logic consistent across the app and extension. and future changes will be much easier. 
- Impact on downstream apps, link to issues or PRs for migration (TODO)
- Ordinals Transfer and Ordinal Recover

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
