### PR TITLE
fix: unit test and fix fetchStxPendingTxData function

### DIFF
--- a/api/helper.ts
+++ b/api/helper.ts
@@ -151,20 +151,24 @@ export function parseBtcTransactionData(
   return parsedTx;
 }
 
-export function deDuplicatePendingTx({
+export function getUniquePendingTx({
   confirmedTransactions,
   pendingTransactions,
 }: {
   confirmedTransactions: StxTransactionData[];
   pendingTransactions: StxMempoolTransactionData[];
 }): StxMempoolTransactionData[] {
-  const txArray: StxMempoolTransactionData[] = [];
-  for (const tx of [...confirmedTransactions, ...pendingTransactions]) {
-    if (!txArray.find((t) => t.txid === tx.txid)) {
-      txArray.push(tx as StxMempoolTransactionData);
-    }
+  if (!pendingTransactions.length) {
+    return pendingTransactions;
   }
-  return txArray;
+  return [
+    ...new Map(
+      pendingTransactions
+        .filter((pendingTx) => pendingTx.incoming !== true)
+        .filter((pendingTx) => !confirmedTransactions.find((confirmedTx) => confirmedTx.txid === pendingTx.txid))
+        .map((m) => [m.txid, m]),
+    ).values(),
+  ];
 }
 
 export function mapTransferTransactionData({

--- a/api/stacks.ts
+++ b/api/stacks.ts
@@ -31,8 +31,8 @@ import {
 import { API_TIMEOUT_MILLI } from '../constant';
 import { AddressToBnsResponse, CoinMetaData, CoreInfo, DelegationInfo } from '../types/api/stacks/assets';
 import {
-  deDuplicatePendingTx,
   getNetworkURL,
+  getUniquePendingTx,
   mapTransferTransactionData,
   parseMempoolStxTransactionsData,
   parseStxTransactionData,
@@ -151,7 +151,7 @@ export async function fetchStxAddressData(
   ]);
 
   const confirmedCount = confirmedTransactions.totalCount;
-  const mempoolCount = deDuplicatePendingTx({
+  const mempoolCount = getUniquePendingTx({
     confirmedTransactions: confirmedTransactions.transactionsList,
     pendingTransactions: mempoolTransactions.transactionsList,
   }).length;
@@ -357,6 +357,7 @@ export async function fetchAddressOfBnsName(
 }
 
 export async function fetchStxPendingTxData(stxAddress: string, network: StacksNetwork): Promise<StxPendingTxData> {
+
   const [confirmedTransactions, mempoolTransactions] = await Promise.all([
     getConfirmedTransactions({
       stxAddress,
@@ -370,10 +371,10 @@ export async function fetchStxPendingTxData(stxAddress: string, network: StacksN
     }),
   ]);
 
-  const pendingTransactions = deDuplicatePendingTx({
+  const pendingTransactions = getUniquePendingTx({
     confirmedTransactions: confirmedTransactions.transactionsList,
     pendingTransactions: mempoolTransactions.transactionsList,
-  }).filter((tx) => tx.incoming === false);
+  });
 
   return {
     pendingTransactions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",
         "@scure/btc-signer": "^1.0.0",
-        "@secretkeylabs/xverse-core": "file:",
         "@stacks/auth": "^6.5.1",
         "@stacks/encryption": "6.1.1",
         "@stacks/network": "4.3.5",
@@ -800,10 +799,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
-    },
-    "node_modules/@secretkeylabs/xverse-core": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/@stacks/auth": {
       "version": "6.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secretkeylabs/xverse-core",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",
         "@scure/btc-signer": "^1.0.0",
+        "@secretkeylabs/xverse-core": "file:",
         "@stacks/auth": "^6.5.1",
         "@stacks/encryption": "6.1.1",
         "@stacks/network": "4.3.5",
@@ -799,6 +800,10 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@secretkeylabs/xverse-core": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@stacks/auth": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@noble/secp256k1": "^1.7.1",
     "@scure/base": "^1.1.1",
     "@scure/btc-signer": "^1.0.0",
-    "@secretkeylabs/xverse-core": "file:",
     "@stacks/auth": "^6.5.1",
     "@stacks/encryption": "6.1.1",
     "@stacks/network": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@noble/secp256k1": "^1.7.1",
     "@scure/base": "^1.1.1",
     "@scure/btc-signer": "^1.0.0",
+    "@secretkeylabs/xverse-core": "file:",
     "@stacks/auth": "^6.5.1",
     "@stacks/encryption": "6.1.1",
     "@stacks/network": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretkeylabs/xverse-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "dist/index.js",
   "dependencies": {

--- a/tests/api/helper.test.ts
+++ b/tests/api/helper.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { getUniquePendingTx } from 'api/helper';
+import { StxMempoolTransactionData, StxTransactionData } from 'types/*';
+
+describe('getUniquePendingTx', () => {
+  [
+    {
+      name: 'returns empty for no pending transactions',
+      inputs: {
+        confirmedTransactions: [
+          { senderAddress: 'address1', txid: 'tx1' } as StxTransactionData,
+          { senderAddress: 'address1', txid: 'tx2' } as StxTransactionData,
+        ],
+        pendingTransactions: [],
+      },
+      expected: [],
+    },
+    {
+      name: 'returns pending transactions not also seen in confirmed transactions',
+      inputs: {
+        confirmedTransactions: [
+          { senderAddress: 'address1', txid: 'tx1' } as StxTransactionData,
+          { senderAddress: 'address1', txid: 'tx2' } as StxTransactionData,
+        ],
+        pendingTransactions: [
+          { senderAddress: 'address1', txid: 'tx2' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData,
+        ],
+      },
+      expected: [{ senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData],
+    },
+    {
+      name: 'returns unique pending transactions not also seen in confirmed transactions',
+      inputs: {
+        confirmedTransactions: [
+          { senderAddress: 'address1', txid: 'tx1' } as StxTransactionData,
+          { senderAddress: 'address1', txid: 'tx2' } as StxTransactionData,
+        ],
+        pendingTransactions: [
+          { senderAddress: 'address1', txid: 'tx2' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData,
+        ],
+      },
+      expected: [{ senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData],
+    },
+    {
+      name: 'returns only pending transactions which are not incoming',
+      inputs: {
+        confirmedTransactions: [
+          { senderAddress: 'address1', txid: 'tx1' } as StxTransactionData,
+          { senderAddress: 'address1', txid: 'tx2' } as StxTransactionData,
+        ],
+        pendingTransactions: [
+          { senderAddress: 'address1', txid: 'tx2' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData,
+          { senderAddress: 'address1', txid: 'tx4', incoming: true } as StxMempoolTransactionData,
+        ],
+      },
+      expected: [{ senderAddress: 'address1', txid: 'tx3' } as StxMempoolTransactionData],
+    },
+  ].forEach(({ name, inputs, expected }) => {
+    it(name, () => {
+      expect(getUniquePendingTx(inputs)).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
Issue Link: https://linear.app/xverseapp/issue/ENG-2581/unit-test-and-fix-fetch-fetchpendingstxtransactions-function
Context Link (if applicable):

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
- fix logic in fetchStxPendingTxData
- add unit tests

Impact:
- fetchStxPendingTxData
- fetchStxAddressData (total_transactions)

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
