### PR TITLE
fix internalPublicKey update with default

### DIFF
--- a/transactions/psbt.ts
+++ b/transactions/psbt.ts
@@ -113,11 +113,12 @@ export async function signPsbt(
         // If input is taproot type and didn't set tapInternalKey,
         // assume it is implied to be the account's publicKey
         const input = psbt.getInput(signingIndex);
-        const witnessOutputScript = input.witnessUtxo?.script &&
-          btc.OutScript.decode(input.witnessUtxo.script);
+        const witnessOutputScript = input.witnessUtxo?.script && btc.OutScript.decode(input.witnessUtxo.script);
 
         if (!input.tapInternalKey && witnessOutputScript?.type === 'tr') {
-          input.tapInternalKey = toXOnly(Buffer.from(publicKey, 'hex'));
+          psbt.updateInput(signingIndex, {
+            tapInternalKey: toXOnly(Buffer.from(publicKey, 'hex')),
+          });
         }
 
         if (inputToSign.sigHash) {
@@ -261,13 +262,11 @@ export function parsePsbt(
         // @ts-expect-error: accessing private property
         pubkey: outputScript.pubkey,
       });
-    } 
-    else if(outputScript.type === 'unknown'){
+    } else if (outputScript.type === 'unknown') {
       //for script outputs
       script = btc.Script.decode(outputScript.script);
-    }
-    else {
-       // @ts-expect-error: accessing private property
+    } else {
+      // @ts-expect-error: accessing private property
       outputAddress = btc.Address(btcNetwork).encode({
         type: outputScript.type,
         // @ts-expect-error: accessing private property


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

update psbt with account publicKey 

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
testing a `psbt` with no provided `TapInternalPublicKey` for a taproot input resulted in the extension failing to sign the input 

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
- updating the `psbt` with the account default `TapInternalPublicKey` is done using the correct method

Impact:
- developers will be able to skip adding the user's public key to taproot Inputs when creating a `psbt`

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
