### PR TITLE
chore: use release published to trigger a release-package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -2,7 +2,7 @@ name: Release & Publish Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
# 🔘 PR Type

- [x] CI related changes

# 📜 Background
Currently the workflow doesn't get triggered if I create a Draft first and then Publish it (in two steps)

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Impact:
- CI only