### PR TITLE
fix: guard against read properties of undefined errors in stx helper function

### DIFF
--- a/api/helper.ts
+++ b/api/helper.ts
@@ -329,23 +329,27 @@ export function parseStxTransactionData({
 
   // add token transfer data if type is token transfer
   if (parsedTx.txType === 'token_transfer') {
+    const amount = new BigNumber(responseTx.token_transfer?.amount ?? 0);
     parsedTx.tokenTransfer = {
-      recipientAddress: responseTx.token_transfer.recipient_address,
-      amount: new BigNumber(responseTx.token_transfer.amount),
-      memo: responseTx.token_transfer.memo,
+      recipientAddress: responseTx.token_transfer?.recipient_address,
+      amount,
+      memo: responseTx.token_transfer?.memo,
     };
-    const amount = new BigNumber(responseTx.token_transfer.amount);
     parsedTx.amount = amount;
   }
   if (parsedTx.txType === 'contract_call') {
     parsedTx.contractCall = responseTx.contract_call;
-    if (responseTx.contract_call?.function_name === 'transfer') {
-      if (responseTx.post_conditions && responseTx.post_conditions.length > 0) {
-        parsedTx.tokenType = responseTx.post_conditions.find((x) => x !== undefined)?.type;
-        parsedTx.amount = new BigNumber(responseTx.post_conditions.find((x) => x !== undefined)?.amount ?? 0);
-        parsedTx.tokenName = responseTx.post_conditions.find((x) => x !== undefined)?.asset.asset_name;
-        if (responseTx.post_conditions.find((x) => x !== undefined)?.asset_value)
-          parsedTx.assetId = responseTx.post_conditions.find((x) => x !== undefined)?.asset_value?.repr.substring(1);
+    if (
+      responseTx.contract_call?.function_name === 'transfer' &&
+      responseTx.post_conditions &&
+      responseTx.post_conditions.length > 0
+    ) {
+      const firstPostCondition = responseTx.post_conditions.find(Boolean);
+      parsedTx.tokenType = firstPostCondition?.type;
+      parsedTx.amount = new BigNumber(firstPostCondition?.amount ?? 0);
+      parsedTx.tokenName = firstPostCondition?.asset?.asset_name;
+      if (firstPostCondition?.asset_value) {
+        parsedTx.assetId = firstPostCondition.asset_value.repr?.substring(1);
       }
     }
   }

--- a/api/helper.ts
+++ b/api/helper.ts
@@ -298,6 +298,12 @@ export function parseMempoolStxTransactionsData({
   return parsedTx;
 }
 
+/**
+ * parseStxTransactionData
+ * @param responseTx StxTransactionDataResponse
+ * @param stxAddress string
+ * @returns StxTransactionData parsed for display
+ */
 export function parseStxTransactionData({
   responseTx,
   stxAddress,

--- a/tests/api/helper.test.ts
+++ b/tests/api/helper.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { getUniquePendingTx } from 'api/helper';
-import { StxMempoolTransactionData, StxTransactionData } from 'types/*';
+import { getUniquePendingTx, parseStxTransactionData } from 'api/helper';
+import {
+  StxMempoolTransactionData,
+  StxMempoolTransactionDataResponse,
+  StxTransactionData,
+  StxTransactionDataResponse,
+} from 'types/*';
+import { TransactionType } from 'types/api/shared/transaction';
 
 describe('getUniquePendingTx', () => {
   [
@@ -64,5 +70,26 @@ describe('getUniquePendingTx', () => {
     it(name, () => {
       expect(getUniquePendingTx(inputs)).toEqual(expected);
     });
+  });
+});
+
+describe('parseStxTransactionData', () => {
+  it('does not throw if post condition has no asset', () => {
+    const inputs = {
+      responseTx: {
+        tx_type: 'contract_call' as TransactionType,
+        contract_call: {
+          function_name: 'transfer',
+        },
+        post_conditions: [
+          {
+            type: '',
+            amount: 0,
+          },
+        ],
+      } as unknown as StxTransactionDataResponse,
+      stxAddress: 'address1',
+    };
+    expect(() => parseStxTransactionData(inputs)).not.toThrow();
   });
 });

--- a/types/api/shared/transaction.ts
+++ b/types/api/shared/transaction.ts
@@ -6,7 +6,8 @@ export type TransactionType =
   | 'poison_microblock'
   | 'bitcoin'
   | 'unsupported'
-  | 'brc20';
+  | 'brc20'
+  | 'message_sign';
 
 export type TransactionStatus =
   | 'pending'


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
user reported extension crashing

Issue Link: https://linear.app/xverseapp/issue/ENG-2619/crash-on-loading
Context Link (if applicable):

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
- guard against read properties of undefined errors in stx helper function

Impact:
- called from web-extension when displaying STX transactions
- also opened a PR for mobile to use this function

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
