### PR TITLE
fix: remove array.at usage as not supported in Native

### DIFF
--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -77,7 +77,7 @@ export async function getOrdinalIdFromUtxo(utxo: UTXO) {
 
   const ordinalIds = await axios.get<string[]>(ordinalContentUrl);
   if (ordinalIds.data.length > 0) {
-    return ordinalIds.data.at(-1);
+    return ordinalIds.data[ordinalIds.data.length - 1];
   } else {
     return null;
   }


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
Array.at was used in a function, but that syntax is not supported in React Native. This PR changes to using the alternative syntax.

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)


Impact:
The getOrdinalIdFromUtxo was failing in the mobile app. This is used in BTC recovery, which is currently not working as a result.

# ✅ Review checklist
Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
