### PR TITLE
fix: ordinals recover tx

### DIFF
--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -11,13 +11,15 @@ import {
   filterUtxos,
   getBtcFees,
   getBtcFeesForOrdinalSend,
+  getBtcFeesForOrdinalTransaction,
   getFee,
   selectUnspentOutputs,
   signBtcTransaction,
   signOrdinalSendTransaction,
+  signOrdinalTransaction,
   sumUnspentOutputs,
 } from '../../transactions/btc';
-import { UTXO } from '../../types';
+import { Inscription, UTXO } from '../../types';
 import { getBtcPrivateKey } from '../../wallet';
 import { testSeed } from '../mocks/restore.mock';
 
@@ -804,6 +806,96 @@ describe('bitcoin transactions', () => {
     // Needs a better transaction size calculator
     expect(signedTx.fee.toNumber()).eq(fee.toNumber());
   });
+
+  it('can calculate fee for ordinal send transaction', async () => {
+    const network = 'Mainnet';
+
+    const ordinal: Inscription = {
+      address: 'bc1px7mgdeysk3jpm3dzj736cnt3vlc8waqhdnqahhfxd2j4ugyfefcszdrfqg',
+      content_length: 259,
+      content_type: 'text/html',
+      genesis_address: 'bc1pcmnd5zp3c2lggs5g5js3v9dze8kh6kc0e8wuvvzwuhjs3hh3hteshxr0dh',
+      genesis_block_hash: '00000000000000000005168b0a05a252130f626482c09a69d0f027805d65f0c2',
+      genesis_block_height: 800660,
+      genesis_fee: '3000',
+      genesis_timestamp: 1690564657000,
+      genesis_tx_id: '7803025a6946c9d151b8fb866045ebb2ceaaa0bb39cbe826ca212792e4696b11',
+      id: '7803025a6946c9d151b8fb866045ebb2ceaaa0bb39cbe826ca212792e4696b11i0',
+      location: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923:0:0',
+      mime_type: 'text/html',
+      number: 19970390,
+      offset: '0',
+      output: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923:0',
+      sat_coinbase_height: 665491,
+      sat_ordinal: '1859682051650570',
+      sat_rarity: 'common',
+      timestamp: 1692653665000,
+      tx_id: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923',
+      value: '10000',
+    };
+
+    const recipientAddress = 'bc1p5dmqqdmxkzfu7xnatft3qgkj9jzf47zxjuwa4ggws0m3vaa6ypmqa5p8h0';
+    const ordinalsAddress = 'bc1px7mgdeysk3jpm3dzj736cnt3vlc8waqhdnqahhfxd2j4ugyfefcszdrfqg';
+    const btcAddress = '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe';
+
+    const { fee } = await getBtcFeesForOrdinalTransaction({
+      recipientAddress,
+      btcAddress,
+      ordinalsAddress,
+      network,
+      ordinal: ordinal,
+    });
+
+    const expectedFee = 2680;
+
+    expect(fee.toNumber()).eq(expectedFee);
+  }, 10000);
+
+  it('can sign ordinal send transaction', async () => {
+    const network = 'Mainnet';
+
+    const ordinal: Inscription = {
+      address: 'bc1px7mgdeysk3jpm3dzj736cnt3vlc8waqhdnqahhfxd2j4ugyfefcszdrfqg',
+      content_length: 259,
+      content_type: 'text/html',
+      genesis_address: 'bc1pcmnd5zp3c2lggs5g5js3v9dze8kh6kc0e8wuvvzwuhjs3hh3hteshxr0dh',
+      genesis_block_hash: '00000000000000000005168b0a05a252130f626482c09a69d0f027805d65f0c2',
+      genesis_block_height: 800660,
+      genesis_fee: '3000',
+      genesis_timestamp: 1690564657000,
+      genesis_tx_id: '7803025a6946c9d151b8fb866045ebb2ceaaa0bb39cbe826ca212792e4696b11',
+      id: '7803025a6946c9d151b8fb866045ebb2ceaaa0bb39cbe826ca212792e4696b11i0',
+      location: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923:0:0',
+      mime_type: 'text/html',
+      number: 19970390,
+      offset: '0',
+      output: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923:0',
+      sat_coinbase_height: 665491,
+      sat_ordinal: '1859682051650570',
+      sat_rarity: 'common',
+      timestamp: 1692653665000,
+      tx_id: '5e6bb85299e9bcbd88dbad799965b7387ec7842652979e5e1ebd0c2dc0867923',
+      value: '10000',
+    };
+
+    const recipientAddress = 'bc1p5dmqqdmxkzfu7xnatft3qgkj9jzf47zxjuwa4ggws0m3vaa6ypmqa5p8h0';
+    const ordinalsAddress = 'bc1px7mgdeysk3jpm3dzj736cnt3vlc8waqhdnqahhfxd2j4ugyfefcszdrfqg';
+    const btcAddress = '3Codr66EYyhkhWy1o2RLmrER7TaaHmtrZe';
+
+    const signedTx = await signOrdinalTransaction({
+      recipientAddress,
+      btcAddress,
+      ordinalsAddress,
+      accountIndex: 0,
+      seedPhrase: testSeed,
+      network,
+      ordinal,
+    });
+
+    const expectedTx =
+      '02000000000103237986c02d0cbd1e5e9e97522684c77e38b7659979addb88bdbce99952b86b5e0000000017160014883999913cffa58d317d4533c94cb94878788db3ffffffffae8ab66c3f56f56f3334e6b589511f361d14adb3f97b1313472c93189185dbde0100000017160014883999913cffa58d317d4533c94cb94878788db3ffffffff7baaa8615b34b330060ac84b76b98d7c552bdea5c8d725161f530861ce0415800100000017160014883999913cffa58d317d4533c94cb94878788db3ffffffff011027000000000000225120a376003766b093cf1a7d5a571022d22c849af846971ddaa10e83f71677ba20760246304302207ca61aed5e28941258b446ea39a02e35e9d89dc75e0dbfef8addaca26b50289b021f63ce519f1a04dd23b886a493579234af78e5efe6a3553e0987abcb1f4a68cd0121032215d812282c0792c8535c3702cca994f5e3da9cd8502c3e190d422f0066fdff02483045022100a5e4b52c2a3c9166b2c9c606e58fe8bf51bfad551c768c04d8311732587b5081022054b001fb40e09cb3c3d034b1e8acbdc0858b1a343752309422bcde704f355b790121032215d812282c0792c8535c3702cca994f5e3da9cd8502c3e190d422f0066fdff02483045022100b2721cc0e3d7d46d2df9c92b63d8c676e607be39be6d1fca0c045dbd355732f602203202cc1af05147e3a6d09a5410e6a2dc8a410a25d5c29e9d0dbac9606f7ce5540121032215d812282c0792c8535c3702cca994f5e3da9cd8502c3e190d422f0066fdff00000000';
+    expect(signedTx.signedTx).eq(expectedTx);
+  }, 10000);
 
   it('can create and sign ordinal send with ordinal utxo in payment address', async () => {
     const network = 'Mainnet';

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -5,7 +5,7 @@ import { hex } from '@scure/base';
 import * as btc from '@scure/btc-signer';
 import BigNumber from 'bignumber.js';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
-import { fetchBtcFeeRate } from '../api/xverse';
+import { fetchBtcFeeRate, getOrdinalsByAddress } from '../api/xverse';
 import { BtcFeeResponse, ErrorCodes, Inscription, NetworkType, ResponseError, UTXO } from '../types';
 import { getBtcPrivateKey, getBtcTaprootPrivateKey } from '../wallet';
 import { selectOptimalUtxos } from './btc.utils';
@@ -419,6 +419,13 @@ export function getOrdinalUtxo(addressUtxos: UTXO[], ordinal: Inscription): UTXO
   return addressUtxos.find((utxo) => `${utxo.txid}:${utxo.vout}` === ordinal.output);
 }
 
+// get ordinals utxos in btc address
+export async function getOrdinalsUtxos(btcAddress: string) {
+  const ordinals = await getOrdinalsByAddress(btcAddress);
+  const filteredOrdinals = ordinals.filter((item) => item.id !== undefined);
+  return filteredOrdinals.map((item) => item.utxo);
+}
+
 // Used to calculate fees for setting low/high fee settings
 // Should replace this function
 export async function getBtcFeesForOrdinalSend(
@@ -501,12 +508,13 @@ export async function getBtcFeesForOrdinalTransaction(feeParams: {
   const address = isRecover ? btcAddress : ordinalsAddress;
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = getOrdinalUtxo(addressUtxos, ordinal);
+  const ordinalsUtxos = await getOrdinalsUtxos(btcAddress);
   if (!ordUtxo) {
     // TODO: Throw error and not just the code
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
   }
-  return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo, btcAddress, network, addressUtxos, feeMode, feeRateInput);
+  return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo, btcAddress, network, ordinalsUtxos, feeMode, feeRateInput);
 }
 
 // Used to calculate fees for setting low/high fee settings
@@ -901,6 +909,7 @@ export async function signOrdinalTransaction(ordinalTxParams: {
   const address = isRecover ? btcAddress : ordinalsAddress;
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = getOrdinalUtxo(addressUtxos, ordinal);
+  const ordinalsUtxos = await getOrdinalsUtxos(btcAddress);
   if (!ordUtxo) {
     // TODO: Throw error and not just the code
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
@@ -913,7 +922,7 @@ export async function signOrdinalTransaction(ordinalTxParams: {
     accountIndex,
     seedPhrase,
     network,
-    addressUtxos,
+    ordinalsUtxos,
     fee,
   );
 }

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -508,13 +508,21 @@ export async function getBtcFeesForOrdinalTransaction(feeParams: {
   const address = isRecover ? btcAddress : ordinalsAddress;
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = getOrdinalUtxo(addressUtxos, ordinal);
-  const ordinalsUtxos = await getOrdinalsUtxos(btcAddress);
+  const addressOrdinalsUtxos = await getOrdinalsUtxos(btcAddress);
   if (!ordUtxo) {
     // TODO: Throw error and not just the code
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw new ResponseError(ErrorCodes.OrdinalUtxoNotfound).statusCode;
   }
-  return getBtcFeesForOrdinalSend(recipientAddress, ordUtxo, btcAddress, network, ordinalsUtxos, feeMode, feeRateInput);
+  return getBtcFeesForOrdinalSend(
+    recipientAddress,
+    ordUtxo,
+    btcAddress,
+    network,
+    addressOrdinalsUtxos,
+    feeMode,
+    feeRateInput,
+  );
 }
 
 // Used to calculate fees for setting low/high fee settings
@@ -909,7 +917,7 @@ export async function signOrdinalTransaction(ordinalTxParams: {
   const address = isRecover ? btcAddress : ordinalsAddress;
   const addressUtxos = await btcClient.getUnspentUtxos(address);
   const ordUtxo = getOrdinalUtxo(addressUtxos, ordinal);
-  const ordinalsUtxos = await getOrdinalsUtxos(btcAddress);
+  const addressOrdinalsUtxos = await getOrdinalsUtxos(btcAddress);
   if (!ordUtxo) {
     // TODO: Throw error and not just the code
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
@@ -922,7 +930,7 @@ export async function signOrdinalTransaction(ordinalTxParams: {
     accountIndex,
     seedPhrase,
     network,
-    ordinalsUtxos,
+    addressOrdinalsUtxos,
     fee,
   );
 }


### PR DESCRIPTION
# 🔘 PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# 📜 Background
The recover ordinal flow was not working properly after the migration of ordinal transaction logic. 

Issue Link: https://linear.app/xverseapp/issue/ENG-2690/fix-ordinal-recover-logic
Context Link (if applicable):

# 🔄 Changes
Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
- added a new function that fetches ordinals utxos in BTC address
- pass ordinals utxos to sign ordinals transaction function

Impact:
- Send Ordinal, Recover Ordinal
- We need to test this PR with following PRs on mobile and extension
https://github.com/secretkeylabs/xverse/pull/1165
https://github.com/secretkeylabs/xverse-web-extension/pull/552

# ✅ Review checklist
Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
