### PR TITLE
feat: add Ordinal UTXO from Xverse API functions

### DIFF
--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -11,6 +11,7 @@ import {
   NetworkType,
   OrdinalTokenTransaction,
   UTXO,
+  UtxoOrdinalBundle,
 } from '../types';
 import { parseBrc20TransactionData } from './helper';
 
@@ -209,3 +210,44 @@ export const isBrcTransferValid = (inscription: Inscription) => {
 
 export const isOrdinalOwnedByAccount = (inscription: Inscription, account: Account) =>
   inscription.address === account.ordinalsAddress;
+
+type AddressBundleResponse = {
+  total: number;
+  offset: number;
+  limit: number;
+  results: UtxoOrdinalBundle[];
+};
+export const getAddressUtxoOrdinalBundles = async (
+  address: string,
+  offset: number,
+  limit: number,
+  options?: {
+    /** Filter out unconfirmed UTXOs */
+    hideUnconfirmed?: boolean;
+    /** Filter out UTXOs that only have one or more inscriptions (and no rare sats) */
+    hideInscriptionOnly?: boolean;
+  },
+) => {
+  const params: Record<string, unknown> = {
+    offset,
+    limit,
+  };
+
+  if (options?.hideUnconfirmed) {
+    params.hideUnconfirmed = 'true';
+  }
+  if (options?.hideInscriptionOnly) {
+    params.hideInscriptionOnly = 'true';
+  }
+
+  const response = await axios.get<AddressBundleResponse>(`${XVERSE_API_BASE_URL}/v1/address/${address}/ordinal-utxo`, {
+    params,
+  });
+
+  return response.data;
+};
+
+export const getUtxoOrdinalBundle = async (txid: string, vout: number): Promise<UtxoOrdinalBundle> => {
+  const response = await axios.get<UtxoOrdinalBundle>(`${XVERSE_API_BASE_URL}/v1/ordinal-utxo/${txid}:${vout}`);
+  return response.data;
+};

--- a/constant.ts
+++ b/constant.ts
@@ -32,7 +32,7 @@ export const BLOCKCYPHER_BASE_URI_TESTNET = 'https://api.blockcypher.com/v1/btc/
 
 export const NFT_BASE_URI = 'https://stacks.gamma.io/api/v1/collections';
 
-export const XVERSE_API_BASE_URL = 'https://api.xverse.app';
+export const XVERSE_API_BASE_URL = 'https://api-3.xverse.app';
 
 export const XVERSE_INSCRIBE_URL = 'https://inscribe.xverse.app';
 

--- a/types/api/xverse/ordinals.ts
+++ b/types/api/xverse/ordinals.ts
@@ -2,3 +2,26 @@ export interface OrdinalInfo {
   inscriptionNumber: string;
   metadata: Record<string, string>;
 }
+
+export type SatRarity = 'common' | 'uncommon' | 'rare' | 'legendary' | 'mythic';
+
+export type BundleRareSat = {
+  number: string;
+  rarity_ranking: SatRarity;
+  offset: number;
+};
+
+export type BundleInscription = {
+  id: string;
+  offset: number;
+  content_type: string;
+};
+
+export type UtxoOrdinalBundle = {
+  txid: string;
+  vout: number;
+  block_height: number;
+  value: number;
+  sats: BundleRareSat[];
+  inscriptions: BundleInscription[];
+};

--- a/types/api/xverse/ordinals.ts
+++ b/types/api/xverse/ordinals.ts
@@ -3,7 +3,7 @@ export interface OrdinalInfo {
   metadata: Record<string, string>;
 }
 
-export type SatRarity = 'common' | 'uncommon' | 'rare' | 'legendary' | 'mythic';
+export type SatRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'mythic';
 
 export type BundleRareSat = {
   number: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -39,7 +39,7 @@ export type {
 } from './api/stacks/assets';
 export * from './api/stacks/transaction';
 export * from './api/xverse/coins';
-export type { OrdinalInfo } from './api/xverse/ordinals';
+export type { OrdinalInfo, UtxoOrdinalBundle } from './api/xverse/ordinals';
 export * from './api/xverse/sponsor';
 export type { Pool, StackerInfo, StackingData, StackingPoolInfo, StackingStateData } from './api/xverse/stacking';
 export * from './api/xverse/transaction';
@@ -47,6 +47,6 @@ export * from './api/xverse/wallet';
 export * from './api/xverseInscribe';
 export type { SupportedCurrency } from './currency';
 export * from './error';
+export * from './mixpanel';
 export * from './network';
 export * from './wallet';
-export * from './mixpanel';


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

- [x] Enhancement

# 📜 Background

Add Ordinal UTXO calls to Xverse API.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- Add get bundles for address end point
- Add get single bundle end point

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
