### PR TITLE
fix: update scure/btc to 1.1.0 to fix bip322 message signing

### DIFF
--- a/connect/bip322Signature.ts
+++ b/connect/bip322Signature.ts
@@ -102,7 +102,7 @@ export const signBip322Message = async ({
     const scriptSig = btc.Script.encode(['OP_0', hex.decode(bip0322Hash(message))]);
     // tx-to-spend
     const txToSpend = new btc.Transaction({
-      allowUnknowOutput: true,
+      allowUnknownOutputs: true,
       version: txVersion,
     });
     txToSpend.addOutput({

--- a/connect/bip322Signature.ts
+++ b/connect/bip322Signature.ts
@@ -117,7 +117,7 @@ export const signBip322Message = async ({
     });
     // tx-to-sign
     const txToSign = new btc.Transaction({
-      allowUnknowOutput: true,
+      allowUnknownOutputs: true,
       version: txVersion,
     });
     txToSign.addInput({

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bitcoinerlab/secp256k1": "^1.0.2",
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",
-        "@scure/btc-signer": "^1.0.0",
+        "@scure/btc-signer": "1.1.0",
         "@stacks/auth": "^6.5.1",
         "@stacks/encryption": "6.1.1",
         "@stacks/network": "4.3.5",
@@ -655,6 +655,28 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
       "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
@@ -713,15 +735,12 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32": {
       "version": "1.1.5",
@@ -766,46 +785,29 @@
       }
     },
     "node_modules/@scure/btc-signer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-1.0.0.tgz",
-      "integrity": "sha512-xBMV/QPWz5BxWQye4DU7133fo9qTgkAcf1RBMSe2zQZHPfpYI1BiC0ITFtHyUbPZvZi0xvstFcXSOW+eKoj/og==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-1.1.0.tgz",
+      "integrity": "sha512-kCX7WaaTJr0VZIXDvaY0wNZfzZoZuLnPz4G0qmKXN8bnNx5M86wb1cce9XrZcfzb0jrVAbZJqNpxmE1e7Ka2hA==",
       "dependencies": {
-        "@noble/curves": "~1.0.0",
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.1",
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.1",
+        "@scure/base": "~1.1.3",
         "micro-packed": "~0.3.2"
-      }
-    },
-    "node_modules/@scure/btc-signer/node_modules/@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "@noble/hashes": "1.3.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@stacks/auth": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@bitcoinerlab/secp256k1": "^1.0.2",
     "@noble/secp256k1": "^1.7.1",
     "@scure/base": "^1.1.1",
-    "@scure/btc-signer": "^1.0.0",
+    "@scure/btc-signer": "1.1.0",
     "@stacks/auth": "^6.5.1",
     "@stacks/encryption": "6.1.1",
     "@stacks/network": "4.3.5",


### PR DESCRIPTION
# 🔘 PR Type

- [x] Bugfix

# 📜 Background
https://linear.app/xverseapp/issue/ENG-2983/testing-the-web-extension-0200-rc1
https://github.com/secretkeylabs/sats-connect-example/pull/13/files

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- update @scure/btc to 1.1.0 and fix the version

Impact:
- bip322 message signing

# 🖼 Screenshot / 📹 Video

https://github.com/secretkeylabs/xverse-core/assets/6109710/aa3599a5-640a-46d4-95a9-ea178baa26dc


# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
