### PR TITLE
fix: change minting seed phrase to getter func (ENG-3124) + UTXO cache args

### DIFF
--- a/api/utxoCache.ts
+++ b/api/utxoCache.ts
@@ -1,3 +1,4 @@
+import { NetworkType } from 'types/network';
 import { UtxoOrdinalBundle } from '../types/api/xverse/ordinals';
 import { AddressBundleResponse, getAddressUtxoOrdinalBundles, getUtxoOrdinalBundle } from './ordinals';
 
@@ -18,15 +19,19 @@ export type StorageAdapter = {
 
 type UtxoCacheConfig = {
   cacheStorageController: StorageAdapter;
+  network: NetworkType;
 };
 
 export class UtxoCache {
   private readonly _cacheStorageController: StorageAdapter;
 
+  private readonly _network: NetworkType;
+
   private readonly VERSION = 1;
 
   constructor(config: UtxoCacheConfig) {
     this._cacheStorageController = config.cacheStorageController;
+    this._network = config.network;
   }
 
   private getAddressCacheStorageKey = (address: string) => `utxoCache-${address}`;
@@ -61,7 +66,7 @@ export class UtxoCache {
     let page = 1;
     let totalPages = 1;
     while (page <= totalPages) {
-      const response: AddressBundleResponse = await getAddressUtxoOrdinalBundles(address, page, 60);
+      const response: AddressBundleResponse = await getAddressUtxoOrdinalBundles(this._network, address, page, 60);
       const { results, total } = response;
       allData = allData.concat(results);
       totalPages = total;
@@ -70,7 +75,7 @@ export class UtxoCache {
     return allData;
   };
 
-  private _getUtxo = async (txid: string, vout: number) => getUtxoOrdinalBundle(txid, vout);
+  private _getUtxo = async (txid: string, vout: number) => getUtxoOrdinalBundle(this._network, txid, vout);
 
   private getAllUtxos = async (btcAddress: string): Promise<UtxoCacheStruct> => {
     const utxos = await this._getAddressUtxos(btcAddress);

--- a/hooks/brc20/useBrc20TransferExecute.ts
+++ b/hooks/brc20/useBrc20TransferExecute.ts
@@ -7,7 +7,7 @@ import { BRC20ErrorCode, ExecuteTransferProgressCodes, brc20TransferExecute } fr
 
 type Props = {
   /** The seed phrase of the wallet. */
-  seedPhrase: string;
+  getSeedPhrase: () => Promise<string>;
 
   /** The account index of the seed phrase to use. */
   accountIndex: number;
@@ -39,7 +39,7 @@ type Props = {
 
 const useBrc20TransferExecute = (props: Props) => {
   const {
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     tick,
@@ -61,7 +61,7 @@ const useBrc20TransferExecute = (props: Props) => {
     if (running) return;
 
     const innerProps = {
-      seedPhrase,
+      getSeedPhrase,
       accountIndex,
       addressUtxos,
       tick,
@@ -115,7 +115,7 @@ const useBrc20TransferExecute = (props: Props) => {
 
     runTransfer();
   }, [
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     tick,

--- a/hooks/inscriptions/useInscriptionExecute.ts
+++ b/hooks/inscriptions/useInscriptionExecute.ts
@@ -6,7 +6,7 @@ import { CoreError } from '../../utils/coreError';
 import { InscriptionErrorCode, inscriptionMintExecute } from '../../transactions/inscriptionMint';
 
 type Props = {
-  seedPhrase: string;
+  getSeedPhrase: () => Promise<string>;
   accountIndex: number;
   addressUtxos: UTXO[];
   revealAddress: string;
@@ -22,7 +22,7 @@ type Props = {
 
 const useInscriptionExecute = (props: Props) => {
   const {
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     contentType,
@@ -44,7 +44,7 @@ const useInscriptionExecute = (props: Props) => {
     if (running || !!revealTransactionId) return;
 
     const innerProps = {
-      seedPhrase,
+      getSeedPhrase,
       accountIndex,
       addressUtxos,
       revealAddress,
@@ -82,7 +82,7 @@ const useInscriptionExecute = (props: Props) => {
 
     runTransfer();
   }, [
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     contentType,

--- a/tests/api/utxoCache.test.ts
+++ b/tests/api/utxoCache.test.ts
@@ -32,6 +32,7 @@ describe('UtxoCache', () => {
     };
     utxoCache = new UtxoCache({
       cacheStorageController: mockStorageAdapter,
+      network: 'Mainnet',
     });
   });
 

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -226,7 +226,7 @@ describe('brc20MintExecute', () => {
     });
 
     const result = await brc20MintExecute({
-      seedPhrase: mockedSeedPhrase,
+      getSeedPhrase: async () => mockedSeedPhrase,
       accountIndex: mockedAccountIndex,
       addressUtxos: mockedAddressUtxos,
       tick: mockedTick,
@@ -512,7 +512,7 @@ describe('brc20TransferExecute', () => {
 
     // Execute the generator function
     const generator = brc20TransferExecute({
-      seedPhrase: mockedSeedPhrase,
+      getSeedPhrase: async () => mockedSeedPhrase,
       accountIndex: mockedAccountIndex,
       addressUtxos: mockedAddressUtxos,
       tick: mockedTick,

--- a/tests/transactions/inscriptionMint.test.ts
+++ b/tests/transactions/inscriptionMint.test.ts
@@ -261,7 +261,7 @@ describe('inscriptionMintExecute', () => {
       accountIndex: 0,
       changeAddress: 'dummyChangeAddress',
       network: 'Mainnet',
-      seedPhrase: 'dummySeedPhrase',
+      getSeedPhrase: async () => 'dummySeedPhrase',
     });
 
     expect(result).toBe('revealTxnId');
@@ -321,7 +321,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
       }),
     ).rejects.toThrowCoreError(
       'Must have at least one non-inscribed UTXO for inscription',
@@ -343,7 +343,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
       }),
     ).rejects.toThrowCoreError('No available UTXOs', InscriptionErrorCode.INSUFFICIENT_FUNDS);
   });
@@ -370,7 +370,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
       }),
     ).rejects.toThrowCoreError('Fee rate should be a positive number', InscriptionErrorCode.INVALID_FEE_RATE);
   });
@@ -406,7 +406,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
         ...config,
       }),
     ).rejects.toThrowCoreError(
@@ -443,7 +443,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
         ...config,
       }),
     ).rejects.toThrowCoreError(
@@ -472,7 +472,7 @@ describe('inscriptionMintExecute', () => {
         accountIndex: 0,
         changeAddress: 'dummyChangeAddress',
         network: 'Mainnet',
-        seedPhrase: 'dummySeedPhrase',
+        getSeedPhrase: async () => 'dummySeedPhrase',
       }),
     ).rejects.toThrowCoreError(`Content exceeds maximum size of 400000 bytes`, InscriptionErrorCode.CONTENT_TOO_BIG);
   });

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -55,7 +55,7 @@ type TransferEstimateResult = BaseEstimateResult & {
 };
 
 type ExecuteProps = {
-  seedPhrase: string;
+  getSeedPhrase: () => Promise<string>;
   accountIndex: number;
   addressUtxos: UTXO[];
   tick: string;
@@ -168,11 +168,11 @@ export const brc20MintEstimateFees = async (estimateProps: EstimateProps): Promi
 
 export async function brc20MintExecute(executeProps: ExecuteProps): Promise<string> {
   validateProps(executeProps);
-  const { seedPhrase, accountIndex, addressUtxos, tick, amount, revealAddress, changeAddress, feeRate, network } =
+  const { getSeedPhrase, accountIndex, addressUtxos, tick, amount, revealAddress, changeAddress, feeRate, network } =
     executeProps;
 
   const privateKey = await getBtcPrivateKey({
-    seedPhrase,
+    seedPhrase: await getSeedPhrase(),
     index: BigInt(accountIndex),
     network: 'Mainnet',
   });
@@ -304,7 +304,7 @@ export async function* brc20TransferExecute(executeProps: ExecuteProps & { recip
 > {
   validateProps(executeProps);
   const {
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     tick,
@@ -317,7 +317,7 @@ export async function* brc20TransferExecute(executeProps: ExecuteProps & { recip
   } = executeProps;
 
   const privateKey = await getBtcPrivateKey({
-    seedPhrase,
+    seedPhrase: await getSeedPhrase(),
     index: BigInt(accountIndex),
     network: 'Mainnet',
   });
@@ -339,7 +339,7 @@ export async function* brc20TransferExecute(executeProps: ExecuteProps & { recip
       },
     ],
     accountIndex,
-    seedPhrase,
+    await getSeedPhrase(),
     'Mainnet',
     new BigNumber(1),
   );
@@ -411,7 +411,7 @@ export async function* brc20TransferExecute(executeProps: ExecuteProps & { recip
       },
     ],
     accountIndex,
-    seedPhrase,
+    await getSeedPhrase(),
     'Mainnet',
     new BigNumber(transferFeeEstimate),
   );

--- a/transactions/inscriptionMint.ts
+++ b/transactions/inscriptionMint.ts
@@ -50,7 +50,7 @@ type EstimateResult = BaseEstimateResult & {
 };
 
 type ExecuteProps = {
-  seedPhrase: string;
+  getSeedPhrase: () => Promise<string>;
   accountIndex: number;
   changeAddress: string;
   network: NetworkType;
@@ -156,7 +156,7 @@ export async function inscriptionMintFeeEstimate(estimateProps: EstimateProps): 
 
 export async function inscriptionMintExecute(executeProps: ExecuteProps): Promise<string> {
   const {
-    seedPhrase,
+    getSeedPhrase,
     accountIndex,
     addressUtxos,
     changeAddress,
@@ -205,7 +205,7 @@ export async function inscriptionMintExecute(executeProps: ExecuteProps): Promis
   const inscriptionValue = finalInscriptionValue ?? MINIMUM_INSCRIPTION_VALUE;
 
   const privateKey = await getBtcPrivateKey({
-    seedPhrase,
+    seedPhrase: await getSeedPhrase(),
     index: BigInt(accountIndex),
     network: 'Mainnet',
   });


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

With the seed vault changes, the inscription hooks need to get a function which returns the seed phrase instead of the direct seed phrase to minimize time spent in memory.

# 🔄 Changes

Does this PR introduce a breaking change?

- [x] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- Mobile and the extension will need to pass in a getSeedPhrase function instead of a string to the inscription hooks
- The UTXO cache was also missing args in function calls. We should probably force branch updates on PRs.

Impact:

- This will need to be implemented in the extension and in mobile.

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
