### PR TITLE
fix: Import types via relative path and remove path aliases

### DIFF
--- a/api/gamma.ts
+++ b/api/gamma.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { NftDetailResponse } from 'types';
 import { NFT_BASE_URI } from '../constant';
+import { NftDetailResponse } from '../types';
 
 export async function getNftDetail(
   tokenId: string,

--- a/api/stacks.ts
+++ b/api/stacks.ts
@@ -17,6 +17,7 @@ import {
 } from '@stacks/transactions';
 import axios from 'axios';
 import BigNumber from 'bignumber.js';
+import { API_TIMEOUT_MILLI } from '../constant';
 import {
   AccountAssetsListData,
   FungibleToken,
@@ -25,20 +26,6 @@ import {
   NonFungibleToken,
   StxAddressData,
   StxAddressDataResponse,
-  TokensResponse,
-  TransactionData,
-} from 'types';
-import { API_TIMEOUT_MILLI } from '../constant';
-import { AddressToBnsResponse, CoinMetaData, CoreInfo, DelegationInfo } from '../types/api/stacks/assets';
-import {
-  getNetworkURL,
-  getUniquePendingTx,
-  mapTransferTransactionData,
-  parseMempoolStxTransactionsData,
-  parseStxTransactionData,
-} from './helper';
-
-import {
   StxMempoolResponse,
   StxMempoolTransactionData,
   StxMempoolTransactionListData,
@@ -46,11 +33,21 @@ import {
   StxTransactionData,
   StxTransactionListData,
   StxTransactionResponse,
+  TokensResponse,
   Transaction,
+  TransactionData,
   TransferTransactionsData,
-} from 'types';
+} from '../types';
+import { AddressToBnsResponse, CoinMetaData, CoreInfo, DelegationInfo } from '../types/api/stacks/assets';
 import { ContractInterfaceResponse } from '../types/api/stacks/transaction';
 import { getNftDetail } from './gamma';
+import {
+  getNetworkURL,
+  getUniquePendingTx,
+  mapTransferTransactionData,
+  parseMempoolStxTransactionsData,
+  parseStxTransactionData,
+} from './helper';
 
 // TODO: these methods needs to be refactored
 // reference https://github.com/secretkeylabs/xverse-core/pull/217/files#r1298242728

--- a/api/utxoCache.ts
+++ b/api/utxoCache.ts
@@ -1,5 +1,4 @@
-import { NetworkType } from 'types/network';
-import { UtxoOrdinalBundle } from '../types/api/xverse/ordinals';
+import { NetworkType, UtxoOrdinalBundle } from '../types';
 import { AddressBundleResponse, getAddressUtxoOrdinalBundles, getUtxoOrdinalBundle } from './ordinals';
 
 export type UtxoCacheStruct = {

--- a/api/xverse.ts
+++ b/api/xverse.ts
@@ -1,12 +1,13 @@
 import { StacksTransaction } from '@stacks/transactions';
 import axios, { AxiosResponse } from 'axios';
 import BigNumber from 'bignumber.js';
-import { CollectionMarketDataResponse, CollectionsList } from 'types/api/xverse/ordinals';
 import { API_TIMEOUT_MILLI, XVERSE_API_BASE_URL, XVERSE_SPONSOR_URL } from '../constant';
 import {
   AppInfo,
   BtcFeeResponse,
   CoinsResponse,
+  CollectionMarketDataResponse,
+  CollectionsList,
   Inscription,
   InscriptionInCollectionsList,
   NetworkType,

--- a/api/xverseInscribe.ts
+++ b/api/xverseInscribe.ts
@@ -16,7 +16,7 @@ import {
   InscriptionExecuteOrderRequest,
   InscriptionExecuteOrderResponse,
   NetworkType,
-} from 'types';
+} from '../types';
 
 import { XVERSE_INSCRIBE_URL } from '../constant';
 

--- a/gaia/walletConfig.ts
+++ b/gaia/walletConfig.ts
@@ -3,8 +3,8 @@ import { FetchFn, createFetchFn } from '@stacks/network';
 import { GaiaHubConfig, connectToGaiaHub, uploadToGaiaHub } from '@stacks/storage';
 import { bytesToHex } from '@stacks/transactions';
 import { BIP32Interface } from 'bip32';
-import { Account } from 'types/account';
 import { WALLET_CONFIG_PATH } from '../constant';
+import { Account } from '../types';
 
 export interface ConfigApp {
   origin: string;

--- a/hooks/brc20/useBrc20TransferExecute.ts
+++ b/hooks/brc20/useBrc20TransferExecute.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { NetworkType, UTXO } from 'types';
+import { NetworkType, UTXO } from '../../types';
 import { CoreError } from '../../utils/coreError';
 
 import { BRC20ErrorCode, ExecuteTransferProgressCodes, brc20TransferExecute } from '../../transactions/brc20';

--- a/hooks/inscriptions/useInscriptionExecute.ts
+++ b/hooks/inscriptions/useInscriptionExecute.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { NetworkType, UTXO } from 'types';
+import { NetworkType, UTXO } from '../../types';
 import { CoreError } from '../../utils/coreError';
 
 import { InscriptionErrorCode, inscriptionMintExecute } from '../../transactions/inscriptionMint';

--- a/ledger/transaction.ts
+++ b/ledger/transaction.ts
@@ -2,7 +2,6 @@ import { SingleSigSpendingCondition, createMessageSignature, deserializeTransact
 import axios from 'axios';
 import BigNumber from 'bignumber.js';
 import { Psbt, networks } from 'bitcoinjs-lib';
-import { UTXO } from 'types/api/esplora';
 import { fetchBtcFeeRate } from '../api';
 import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import {
@@ -13,9 +12,7 @@ import {
   selectUnspentOutputs,
   sumUnspentOutputs,
 } from '../transactions/btc';
-import { BtcFeeResponse } from '../types/api/xverse/transaction';
-import { ErrorCodes, ResponseError } from '../types/error';
-import { NetworkType } from '../types/network';
+import { BtcFeeResponse, ErrorCodes, NetworkType, ResponseError, UTXO } from '../types';
 import { MAINNET_BROADCAST_URI, TESTNET_BROADCAST_URI } from './constants';
 import { Bip32Derivation, TapBip32Derivation } from './types';
 

--- a/tests/api/helper.test.ts
+++ b/tests/api/helper.test.ts
@@ -1,12 +1,7 @@
-import { describe, expect, it } from 'vitest';
 import { getUniquePendingTx, parseStxTransactionData } from 'api/helper';
-import {
-  StxMempoolTransactionData,
-  StxMempoolTransactionDataResponse,
-  StxTransactionData,
-  StxTransactionDataResponse,
-} from 'types/*';
-import { TransactionType } from 'types/api/shared/transaction';
+import { describe, expect, it } from 'vitest';
+import { StxMempoolTransactionData, StxTransactionData, StxTransactionDataResponse } from '../../types';
+import { TransactionType } from '../../types/api/shared/transaction';
 
 describe('getUniquePendingTx', () => {
   [

--- a/tests/transactions/brc20.test.ts
+++ b/tests/transactions/brc20.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { UTXO } from 'types';
 import BitcoinEsploraApiProvider from '../../api/esplora/esploraAPiProvider';
 import xverseInscribeApi from '../../api/xverseInscribe';
 import {
@@ -8,6 +7,7 @@ import {
   selectUtxosForSend,
   signNonOrdinalBtcSendTransaction,
 } from '../../transactions/btc';
+import { UTXO } from '../../types';
 import { getBtcPrivateKey } from '../../wallet';
 
 import BigNumber from 'bignumber.js';

--- a/tests/transactions/btc.fixtures.ts
+++ b/tests/transactions/btc.fixtures.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
-import { UTXO } from 'types';
 import { Recipient } from '../../transactions/btc';
+import { UTXO } from '../../types';
 
 import { utxo10k, utxo384k, utxo3k, utxo792k } from './btc.data';
 

--- a/transactions/btcNetwork.ts
+++ b/transactions/btcNetwork.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from 'types/network';
+import { NetworkType } from '../types/network';
 
 export interface BitcoinNetwork {
   bech32: string;

--- a/transactions/inscriptionMint.ts
+++ b/transactions/inscriptionMint.ts
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js';
 
-import { NetworkType, UTXO } from 'types';
 import { getOrdinalIdsFromUtxo } from '../api/ordinals';
 import xverseInscribeApi from '../api/xverseInscribe';
+import { NetworkType, UTXO } from '../types';
 import { CoreError } from '../utils/coreError';
 import { getBtcPrivateKey } from '../wallet';
 import { generateSignedBtcTransaction, selectUtxosForSend } from './btc';

--- a/transactions/stacking.ts
+++ b/transactions/stacking.ts
@@ -14,7 +14,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { address } from 'bitcoinjs-lib';
 import BN from 'bn.js';
-import { StacksNetwork, StacksTransaction, StxMempoolTransactionData } from 'types';
+import { StacksNetwork, StacksTransaction, StxMempoolTransactionData } from '../types';
 import { getNewNonce } from './helper';
 import { estimateContractCallFees, generateUnsignedContractCall, getNonce, setFee, setNonce } from './stx';
 

--- a/transactions/stx.ts
+++ b/transactions/stx.ts
@@ -43,7 +43,8 @@ import {
   standardPrincipalCV,
   uintCV,
 } from '@stacks/transactions';
-import { PostConditionsOptions, StxMempoolTransactionData } from 'types';
+import BigNumber from 'bignumber.js';
+import { PostConditionsOptions, StxMempoolTransactionData } from '../types';
 import {
   UnsignedContractCallTransaction,
   UnsignedContractDeployOptions,
@@ -51,7 +52,6 @@ import {
 } from '../types/api/stacks/transaction';
 import { getStxAddressKeyChain } from '../wallet/index';
 import { getNewNonce, makeFungiblePostCondition, makeNonFungiblePostCondition } from './helper';
-import BigNumber from 'bignumber.js';
 
 export interface StacksRecipient {
   address: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,6 @@
     "module": "ES6",
     "moduleResolution": "node",
     "baseUrl": ".",
-    "paths": {
-      "types/*": ["./types"],
-      "currency/*": ["./currency"],
-      "transactions/*": ["./transactions"],
-      "wallet/*": ["./wallet"],
-      "stacking/*": ["./stacking"],
-      "account/*": ["./account"],
-      "gaia/*": ["./gaia"]
-    },
     "declaration": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/types/api/stacks/transaction.ts
+++ b/types/api/stacks/transaction.ts
@@ -9,7 +9,7 @@ import {
   cvToHex,
   uintCV,
 } from '@stacks/transactions';
-import { StxMempoolTransactionData } from 'types/network';
+import { StxMempoolTransactionData } from '../../../types';
 import { ContractCall, TransactionPostCondition, TransactionStatus, TransactionType } from '../shared/transaction';
 
 export { cvToHex, uintCV };

--- a/types/api/xverseInscribe/brc20.ts
+++ b/types/api/xverseInscribe/brc20.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from 'types/network';
+import { NetworkType } from '../../../types';
 
 type Brc20TransferOrMintRequest = {
   operation: 'transfer' | 'mint';

--- a/wallet/index.ts
+++ b/wallet/index.ts
@@ -13,13 +13,10 @@ import {
   publicKeyToString,
 } from '@stacks/transactions';
 import * as bip39 from 'bip39';
-import { AddressType, getAddressInfo, Network as btcAddressNetwork, validate } from 'bitcoin-address-validation';
+import { AddressType, Network as btcAddressNetwork, getAddressInfo, validate } from 'bitcoin-address-validation';
 import { networks, payments } from 'bitcoinjs-lib';
 import { c32addressDecode } from 'c32check';
 import crypto from 'crypto';
-import { Keychain } from 'types/api/xverse/wallet';
-import { NetworkType } from 'types/network';
-import { BaseWallet } from 'types/wallet';
 import {
   BTC_SEGWIT_PATH_PURPOSE,
   BTC_TAPROOT_PATH_PURPOSE,
@@ -28,6 +25,7 @@ import {
   STX_PATH_WITHOUT_INDEX,
 } from '../constant';
 import { getBtcNetwork } from '../transactions/btcNetwork';
+import { BaseWallet, Keychain, NetworkType } from '../types';
 import { BIP32Interface, bip32 } from '../utils/bip32';
 import { ECPair } from '../utils/ecpair';
 import { ecPairToHexString } from './helper';
@@ -282,8 +280,8 @@ export async function getStxAddressKeyChain(
   return deriveStxAddressKeychain(rootNode);
 }
 
-export { hashMessage };
 export * from './encryptionUtils';
+export { hashMessage };
 
 export const validateBtcAddressIsTaproot = (btcAddress: string): boolean => {
   try {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

We had type aliases set up in tsconfig which were not being post-processed after a build. These were causing typing issues in our consuming applications.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- Path aliases were removed from tsconfig.ts. 
- Only the "type" alias was used, so all imports from 'type' were changed to relative imports

Impact:

- This has no functional affect, only typing. It should fix some typing issues in the mobile and extension repos.

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
