### PR TITLE
fix: add a full bns collection id for bns collectibles

### DIFF
--- a/api/stacks.ts
+++ b/api/stacks.ts
@@ -268,7 +268,7 @@ export async function getNftsData(
   const apiUrl = `${getNetworkURL(network)}/extended/v1/tokens/nft/holdings`;
 
   const response = await axios.get<NftEventsResponse>(apiUrl, {
-    timeout: 30000,
+    timeout: 10000,
     params: {
       principal: stxAddress,
       offset: offset,

--- a/constant.ts
+++ b/constant.ts
@@ -51,6 +51,8 @@ export const HIRO_MAINNET_DEFAULT = 'https://api.hiro.so';
 
 export const HIRO_TESTNET_DEFAULT = 'https://api.testnet.hiro.so';
 
+export const BNS_CONTRACT_ID = 'SP000000000000000000002Q6VF78.bns';
+
 export const supportedCoins = [
   {
     contract: 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.age000-governance-token',

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { StacksNetwork } from '@stacks/network';
 import BigNumber from 'bignumber.js';
+import { BNS_CONTRACT_ID } from '../constant';
 import { NftCollectionData, NftDetailResponse, NftEventsResponse, NonFungibleToken } from 'types';
 import { getNftDetail, getNftsCollectionData } from '../api/gamma';
 import { getNftsData } from '../api/stacks';
@@ -59,9 +60,10 @@ async function fetchBatchData(batch: Array<NonFungibleToken>, collectionRecord: 
     const contractId = principal[0];
 
     if (contractInfo[1] === 'bns') {
-      //no further data required for BNS, arrange into collection
+      // no further data required for BNS, arrange into collection
+      // currently stacks only supports 1 bns name per address
       const bnsCollection: StacksCollectionData = {
-        collection_id: 'bns',
+        collection_id: contractId,
         collection_name: 'BNS Names',
         total_nft: 1,
         thumbnail_nfts: [nft],
@@ -150,8 +152,8 @@ function sortNftCollectionList(nftCollectionList: StacksCollectionData[]) {
   //sort according to total nft in a collection
   return nftCollectionList.sort((a, b) => {
     //place bns collection at the bottom of nft list
-    if (a.collection_id === 'bns') return 1;
-    else if (b.collection_id === 'bns') return -1;
+    if (a.collection_id === BNS_CONTRACT_ID) return 1;
+    else if (b.collection_id === BNS_CONTRACT_ID) return -1;
     return b.total_nft - a.total_nft;
   });
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,6 +37,7 @@ export type {
   NftEventsResponse,
   NftsListData,
   NonFungibleToken,
+  TokenMetaData,
 } from './api/stacks/assets';
 export * from './api/stacks/transaction';
 export * from './api/xverse/coins';

--- a/types/index.ts
+++ b/types/index.ts
@@ -33,6 +33,7 @@ export type {
   AddressToBnsResponse,
   CoinMetaData,
   CoreInfo,
+  NftData,
   NftEventsResponse,
   NftsListData,
   NonFungibleToken,


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix
- [x] Enhancement

# 📜 Background
required for https://linear.app/xverseapp/issue/ENG-3145/add-bns-name-detail-page

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- use 10s timeout for nft holdings fetch
- supply bns contract id as collection id, so frontend can treat it the same to show contract id, name, etc.
- add some missing types

Impact:
- stx nft collectibles tab (bns collection and detail page)
- the 10s timeout for nft holdings means the nfts tab will show the API error message quicker (but should still retry with the react-query retries 3 times)

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
