### PR TITLE
Extend supported fiat currencies to include Swiss Franc (CHF)

### DIFF
--- a/types/currency.ts
+++ b/types/currency.ts
@@ -23,7 +23,8 @@ export type SupportedCurrency =
   | 'SGD'
   | 'GBP'
   | 'BRL'
-  | 'RUB';
+  | 'RUB'
+  | 'CHF';
 
 export const currencySymbolMap: Record<SupportedCurrency, string> = {
   USD: '$',
@@ -38,4 +39,5 @@ export const currencySymbolMap: Record<SupportedCurrency, string> = {
   GBP: '£',
   BRL: 'R$',
   RUB: '₽',
+  CHF: '₣',
 };


### PR DESCRIPTION
# 🔘 PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background

Previously, xverse-core supported only to compute the conversion rates for USD, EUR, CAD, CNY, ARS, KRW, HKD, JPY, SGD, GBP, BRL, RUB. This PR extends the support to Swiss Francs. In fact, the xverse.app api for the mainnet as well as for the testnet support Swiss Francs already:
```bash
curl 'https://api-testnet.xverse.app/v1/prices/btc/CHF'
curl 'https://api-3.xverse.app/v1/prices/btc/CHF'
```


# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- Changes were only made to `types/currency.ts `

Impact:

- Allows for other software, e.g., the xverse-web-extension,  to compute the Swiss Francs conversion rates.

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
