### PR TITLE
feat: add total_nfts prop to getNftCollections response

### DIFF
--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -20,6 +20,7 @@ export interface StacksCollectionList {
   offset: number;
   limit: number;
   total: number;
+  total_nfts: number;
   results: Array<StacksCollectionData>;
 }
 
@@ -206,6 +207,7 @@ export async function getNftCollections(
   limit: number,
 ): Promise<StacksCollectionList> {
   const nftCollectionList = await checkCacheOrFetchNFTCollection(stxAddress, network);
+  const total_nfts = nftCollectionList.reduce((total, collection) => total + collection.total_nft, 0);
 
   const requiredSortedCollectionsData = nftCollectionList?.slice(offset, offset + limit);
 
@@ -213,6 +215,7 @@ export async function getNftCollections(
     offset,
     limit,
     total: nftCollectionList.length,
+    total_nfts,
     results: requiredSortedCollectionsData,
   };
 }


### PR DESCRIPTION
# 🔘 PR Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background

This PR adds the total_nfts prop to getNftCollections method

Issue Link: #[ENG-3223](https://linear.app/xverseapp/issue/ENG-3223/add-the-totalnfts-information-for-stacks-nft-response-in-core)


# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- add total_nfts prop to getNftCollections method

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
