### PR TITLE
fix: improve UTXO selection for spend

### DIFF
--- a/ledger/transaction.ts
+++ b/ledger/transaction.ts
@@ -51,7 +51,12 @@ export async function getTransactionData(
   // Get total sats to send (including custom fee)
   const amountSats = recipients.reduce((acc, value) => acc.plus(value.amountSats), new BigNumber(0));
 
-  let selectedUTXOs = selectUnspentOutputs(amountSats, filteredUnspentOutputs, ordinalUtxo);
+  let selectedUTXOs = selectUnspentOutputs(
+    amountSats,
+    filteredUnspentOutputs,
+    ordinalUtxo,
+    feeRateInput ? Number(feeRateInput) : undefined,
+  );
   let sumOfSelectedUTXOs = sumUnspentOutputs(selectedUTXOs);
 
   if (sumOfSelectedUTXOs.isLessThan(amountSats)) {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Enhancement

# 📜 Background

When selecting UTXOs to spend, we always take the biggest one as highest priority. This is problematic if a big UTXO is affected by a dust attack as it would be used over and over without being confirmed, potentially resulting in a chain of transactions with length of 25, the maximum allowed by Bitcoin.

If another transaction is executed and the last UTXO from that chain is the biggest, we would try to spend it again, resulting in a 400 from the Bitcoin node when trying to broadcast the transaction due to the long chain. This would effectively block your wallet from making transactions as that UTXO will always be picked first.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- The logic to select which UTXOs to spend is changed, prioritising confirmed UTXOs primarily, and secondarily their value (biggest is higher priority)
- An additional step was added to further avoid spending dust UTXOs by ensuring that a UTXO added to a transaction increases the fee rate (if it decreases it, then it is dust at that fee rate)

Impact:

- Avoids the above described scenario with the long chain of txns
- Improves dust resiliency

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
