### PR TITLE
fix: raise the holdings fetch limit to max at 200

### DIFF
--- a/api/stacks.ts
+++ b/api/stacks.ts
@@ -264,6 +264,7 @@ export async function getNftsData(
   stxAddress: string,
   network: StacksNetwork,
   offset: number,
+  limit?: number,
 ): Promise<NftEventsResponse> {
   const apiUrl = `${getNetworkURL(network)}/extended/v1/tokens/nft/holdings`;
 
@@ -271,7 +272,8 @@ export async function getNftsData(
     timeout: 10000,
     params: {
       principal: stxAddress,
-      offset: offset,
+      offset,
+      limit,
     },
   });
 

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -190,7 +190,7 @@ async function checkCacheOrFetchNFTCollection(
     return cachedValue;
   }
 
-  const nfts = await getAllNftContracts(stxAddress, network, 200);
+  const nfts = await getAllNftContracts(stxAddress, network, 200); // limit: 200 is max on the API
 
   const collectionRecord = await fetchNFTCollectionDetailsRecord(nfts);
 

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -29,9 +29,9 @@ export async function getAllNftContracts(address: string, network: StacksNetwork
 
   //make initial call to get the total inscriptions count and limit
   let offset = 0;
-  const response = await getNftsData(address, network, 0);
+  const limit = 200;
+  const response = await getNftsData(address, network, offset, limit);
   const total = response.total;
-  const limit = response.limit;
   offset += limit;
   listofContracts.push(...response.results);
 

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -24,12 +24,15 @@ export interface StacksCollectionList {
   results: Array<StacksCollectionData>;
 }
 
-export async function getAllNftContracts(address: string, network: StacksNetwork): Promise<NonFungibleToken[]> {
+export async function getAllNftContracts(
+  address: string,
+  network: StacksNetwork,
+  limit: number,
+): Promise<NonFungibleToken[]> {
   const listofContracts: Array<NonFungibleToken> = [];
 
   //make initial call to get the total inscriptions count and limit
   let offset = 0;
-  const limit = 200;
   const response = await getNftsData(address, network, offset, limit);
   const total = response.total;
   offset += limit;
@@ -40,7 +43,7 @@ export async function getAllNftContracts(address: string, network: StacksNetwork
   // Make API calls in parallel to speed up fetching data
   while (offset < total) {
     // Add new promise to the array
-    listofContractPromises.push(getNftsData(address, network, offset));
+    listofContractPromises.push(getNftsData(address, network, offset, limit));
     offset += limit;
 
     // When we have 4 promises, or when we are processing the last batch
@@ -187,7 +190,7 @@ async function checkCacheOrFetchNFTCollection(
     return cachedValue;
   }
 
-  const nfts = await getAllNftContracts(stxAddress, network);
+  const nfts = await getAllNftContracts(stxAddress, network, 200);
 
   const collectionRecord = await fetchNFTCollectionDetailsRecord(nfts);
 

--- a/tests/stacks/stacksNfts.test.ts
+++ b/tests/stacks/stacksNfts.test.ts
@@ -51,8 +51,8 @@ describe('getAllNftContracts', () => {
 
     const address = 'SP3RW6BW9F5STYG2K8XS5EP5PM33E0DNQT4XEG864';
     const network = new StacksMainnet();
-    const limit = 10;
-    const totalItems = 35; // Total should not be a multiple of the limit to test edge cases
+    const limit = 200;
+    const totalItems = 3500; // Total should not be a multiple of the limit to test edge cases
     const expectedCalls = Math.ceil(totalItems / limit);
 
     for (let i = 0; i < expectedCalls; i++) {
@@ -61,7 +61,7 @@ describe('getAllNftContracts', () => {
       vi.mocked(getNftsData).mockResolvedValueOnce(await mockResponse(offset, responseLimit, totalItems));
     }
 
-    const contracts = await getAllNftContracts(address, network);
+    const contracts = await getAllNftContracts(address, network, limit);
 
     expect(vi.mocked(getNftsData)).toHaveBeenCalledTimes(expectedCalls);
     expect(contracts).toHaveLength(totalItems);


### PR DESCRIPTION
# 🔘 PR Type
- [x] Bugfix

# 📜 Background
issue: https://linear.app/xverseapp/issue/ENG-3226/api-rate-limit-issue-with-stx-nfts-in-the-collectibles-ui-pr

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:
- fetch stx holdings at 200 per page instead of 150

Impact:
- reduce slightly the likelihood of rate limiting

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
