### PR TITLE
feat: mitigate hiro api is returning duplicate holdings

### DIFF
--- a/api/utxoCache.ts
+++ b/api/utxoCache.ts
@@ -78,7 +78,6 @@ export class UtxoCache {
 
   private getAllUtxos = async (btcAddress: string): Promise<UtxoCacheStruct> => {
     const utxos = await this._getAddressUtxos(btcAddress);
-    console.log(utxos);
     const utxosObject: UtxoCacheStruct = utxos.reduce((acc, utxo) => {
       acc[`${utxo.txid}:${utxo.vout}`] = utxo;
       return acc;

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -131,7 +131,6 @@ export function organizeNFTsIntoCollection(
     if (organized[contractId]) {
       const data = organized[contractId];
       data.all_nfts.push(nft);
-      data.total_nft += 1;
     } else {
       organized[contractId] = {
         collection_id: contractId,

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -145,10 +145,12 @@ export function organizeNFTsIntoCollection(
     }
   }
 
-  Object.keys(organized).forEach((collectionKey) => {
-    organized[collectionKey].all_nfts = organized[collectionKey].all_nfts.sort((a, b) => {
-      return a.identifier.tokenId < b.identifier.tokenId ? -1 : 1;
-    });
+  // sort and unique all_nfts
+  Object.values(organized).forEach((collection) => {
+    const sorted = collection.all_nfts.sort((a, b) => (a.identifier.tokenId < b.identifier.tokenId ? -1 : 1));
+    const unique = new Map(sorted.map((nft) => [nft.identifier.tokenId, nft]));
+    collection.all_nfts = Array.from(unique.values());
+    collection.total_nft = collection.all_nfts.length;
   });
 
   return organized;

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -11,7 +11,6 @@ export interface StacksCollectionData {
   collection_id: string | null;
   collection_name: string | null;
   total_nft: number;
-  thumbnail_nfts: NonFungibleToken[]; //stores a max of four nfts
   all_nfts: NonFungibleToken[]; //stores entire list of nft in collection
   floor_price?: number;
 }
@@ -122,7 +121,6 @@ export function organizeNFTsIntoCollection(
         collection_id: contractId,
         collection_name: 'BNS Names',
         total_nft: 1,
-        thumbnail_nfts: [nft],
         all_nfts: [nft],
       };
     }
@@ -132,11 +130,7 @@ export function organizeNFTsIntoCollection(
     // group NFTs into collections
     if (organized[contractId]) {
       const data = organized[contractId];
-
       data.all_nfts.push(nft);
-      if (data.total_nft < 4) {
-        data?.thumbnail_nfts.push(nft);
-      }
       data.total_nft += 1;
     } else {
       organized[contractId] = {
@@ -144,7 +138,6 @@ export function organizeNFTsIntoCollection(
         collection_name: collectionData?.collection?.name ?? contractId,
         total_nft: 1,
         all_nfts: [nft],
-        thumbnail_nfts: [nft],
         floor_price: collectionData?.collection?.floorItem?.price
           ? microstacksToStx(new BigNumber(collectionData?.collection?.floorItem?.price)).toNumber()
           : 0,

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -151,6 +151,13 @@ export function organizeNFTsIntoCollection(
       };
     }
   }
+
+  Object.keys(organized).forEach((collectionKey) => {
+    organized[collectionKey].all_nfts = organized[collectionKey].all_nfts.sort((a, b) => {
+      return a.identifier.tokenId < b.identifier.tokenId ? -1 : 1;
+    });
+  });
+
   return organized;
 }
 

--- a/stacksCollectible/index.ts
+++ b/stacksCollectible/index.ts
@@ -162,9 +162,7 @@ async function fetchNFTCollectionDetailsRecord(
 
   const { collectionData, nftArray } = await fetchNftData(nfts);
 
-  organizeNFTsIntoCollection(collectionRecord, nftArray, collectionData);
-
-  return collectionRecord;
+  return organizeNFTsIntoCollection(collectionRecord, nftArray, collectionData);
 }
 
 function sortNftCollectionList(nftCollectionList: StacksCollectionData[]) {

--- a/tests/stacks/stacksNfts.test.ts
+++ b/tests/stacks/stacksNfts.test.ts
@@ -277,9 +277,75 @@ describe('organizeNFTsIntoCollection', () => {
       expect(result).toStrictEqual(expected);
     });
 
-    // it('should return sorted all_nfts', () => {
+    it('should return sorted all_nfts by tokenId', () => {
+      const collectionRecord = {};
+      const nftArray: NonFungibleToken[] = [
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1986',
+          },
+          identifier: {
+            tokenId: '1986',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1222',
+          },
+          identifier: {
+            tokenId: '1222',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+      ];
+      const nftCollectionDataArray: NftCollectionData[] = [];
+      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
 
-    // });
+      const expectedAllNfts = [
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1222',
+          },
+          identifier: {
+            tokenId: '1222',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1986',
+          },
+          identifier: {
+            tokenId: '1986',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+      ];
+      const resultAllNfts = result['SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys'].all_nfts;
+      console.log(resultAllNfts);
+      expect(resultAllNfts).toStrictEqual(expectedAllNfts);
+    });
     // it('should return no duplicates', () => {
 
     // });

--- a/tests/stacks/stacksNfts.test.ts
+++ b/tests/stacks/stacksNfts.test.ts
@@ -86,20 +86,6 @@ describe('organizeNFTsIntoCollection', () => {
     it('should return sorted all_nfts', () => {
       const collectionRecord = {};
       const nftArray: NonFungibleToken[] = [
-        // {
-        //   asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
-        //   block_height: 30124,
-        //   tx_id: '0x0eadd48d421907991ba56bbdd707f77c67e341c3ababbc0290a3e0fcac006fac',
-        //   value: {
-        //     hex: '0x0c00000002046e616d65020000000464756c62096e616d6573706163650200000003627463',
-        //     repr: '(tuple (name 0x64756c62) (namespace 0x627463))',
-        //   },
-        //   identifier: {
-        //     tokenId: '(tuple (name 0x64756c62) (namespace 0x627463))',
-        //     contractName: 'names',
-        //     contractAddress: 'SP000000000000000000002Q6VF78.bns',
-        //   },
-        // },
         {
           asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
           block_height: 56107,
@@ -139,22 +125,6 @@ describe('organizeNFTsIntoCollection', () => {
           collection_id: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           collection_name: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           floor_price: 0,
-          thumbnail_nfts: [
-            {
-              asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
-              block_height: 56107,
-              identifier: {
-                contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
-                contractName: 'mutant-monkeys',
-                tokenId: '1986',
-              },
-              tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
-              value: {
-                hex: '0x01000000000000000000000000000007c2',
-                repr: 'u1986',
-              },
-            },
-          ],
           total_nft: 1,
         },
       };
@@ -217,22 +187,6 @@ describe('organizeNFTsIntoCollection', () => {
           collection_id: 'SP000000000000000000002Q6VF78.bns',
           collection_name: 'SP000000000000000000002Q6VF78.bns',
           floor_price: 0,
-          thumbnail_nfts: [
-            {
-              asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
-              block_height: 30124,
-              tx_id: '0x0eadd48d421907991ba56bbdd707f77c67e341c3ababbc0290a3e0fcac006fac',
-              value: {
-                hex: '0x0c00000002046e616d65020000000464756c62096e616d6573706163650200000003627463',
-                repr: '(tuple (name 0x64756c62) (namespace 0x627463))',
-              },
-              identifier: {
-                tokenId: '(tuple (name 0x64756c62) (namespace 0x627463))',
-                contractName: 'names',
-                contractAddress: 'SP000000000000000000002Q6VF78.bns',
-              },
-            },
-          ],
           total_nft: 1,
         },
         'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys': {
@@ -255,22 +209,6 @@ describe('organizeNFTsIntoCollection', () => {
           collection_id: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           collection_name: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           floor_price: 0,
-          thumbnail_nfts: [
-            {
-              asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
-              block_height: 56107,
-              identifier: {
-                contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
-                contractName: 'mutant-monkeys',
-                tokenId: '1986',
-              },
-              tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
-              value: {
-                hex: '0x01000000000000000000000000000007c2',
-                repr: 'u1986',
-              },
-            },
-          ],
           total_nft: 1,
         },
       };
@@ -343,11 +281,90 @@ describe('organizeNFTsIntoCollection', () => {
         },
       ];
       const resultAllNfts = result['SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys'].all_nfts;
-      console.log(resultAllNfts);
       expect(resultAllNfts).toStrictEqual(expectedAllNfts);
     });
-    // it('should return no duplicates', () => {
 
-    // });
+    it('should return no duplicates', () => {
+      const collectionRecord = {};
+      const nftArray: NonFungibleToken[] = [
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1986',
+          },
+          identifier: {
+            tokenId: '1986',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1222',
+          },
+          identifier: {
+            tokenId: '1222',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1986',
+          },
+          identifier: {
+            tokenId: '1986',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+      ];
+      const nftCollectionDataArray: NftCollectionData[] = [];
+      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+
+      const expectedAllNfts = [
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1222',
+          },
+          identifier: {
+            tokenId: '1222',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+        {
+          asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
+          block_height: 56107,
+          tx_id: '0x90a81c4c6b364b1b7034c0a2cc10f142662c7d2af251e1fd31252a2b4b453f27',
+          value: {
+            hex: '0x01000000000000000000000000000007c2',
+            repr: 'u1986',
+          },
+          identifier: {
+            tokenId: '1986',
+            contractName: 'mutant-monkeys',
+            contractAddress: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7',
+          },
+        },
+      ];
+      const resultAllNfts = result['SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys'].all_nfts;
+      expect(resultAllNfts).toStrictEqual(expectedAllNfts);
+    });
   });
 });

--- a/tests/stacks/stacksNfts.test.ts
+++ b/tests/stacks/stacksNfts.test.ts
@@ -74,17 +74,15 @@ describe('getAllNftContracts', () => {
 
 describe('organizeNFTsIntoCollection', () => {
   describe('real address returning duplicated holdings', () => {
-    it('should return a copy of collectionRecord', () => {
-      const collectionRecord = {};
+    it('should return a empty object', () => {
       const nftArray: NonFungibleToken[] = [];
       const nftCollectionDataArray: NftCollectionData[] = [];
-      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+      const result = organizeNFTsIntoCollection(nftArray, nftCollectionDataArray);
 
       const expected = {};
       expect(result).toStrictEqual(expected);
     });
     it('should return sorted all_nfts', () => {
-      const collectionRecord = {};
       const nftArray: NonFungibleToken[] = [
         {
           asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
@@ -102,7 +100,7 @@ describe('organizeNFTsIntoCollection', () => {
         },
       ];
       const nftCollectionDataArray: NftCollectionData[] = [];
-      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+      const result = organizeNFTsIntoCollection(nftArray, nftCollectionDataArray);
 
       const expected = {
         'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys': {
@@ -125,14 +123,12 @@ describe('organizeNFTsIntoCollection', () => {
           collection_id: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           collection_name: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           floor_price: 0,
-          total_nft: 1,
         },
       };
       expect(result).toStrictEqual(expected);
     });
 
     it('should sort bns names', () => {
-      const collectionRecord = {};
       const nftArray: NonFungibleToken[] = [
         {
           asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
@@ -164,31 +160,9 @@ describe('organizeNFTsIntoCollection', () => {
         },
       ];
       const nftCollectionDataArray: NftCollectionData[] = [];
-      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+      const result = organizeNFTsIntoCollection(nftArray, nftCollectionDataArray);
 
       const expected = {
-        'SP000000000000000000002Q6VF78.bns': {
-          all_nfts: [
-            {
-              asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
-              block_height: 30124,
-              tx_id: '0x0eadd48d421907991ba56bbdd707f77c67e341c3ababbc0290a3e0fcac006fac',
-              value: {
-                hex: '0x0c00000002046e616d65020000000464756c62096e616d6573706163650200000003627463',
-                repr: '(tuple (name 0x64756c62) (namespace 0x627463))',
-              },
-              identifier: {
-                tokenId: '(tuple (name 0x64756c62) (namespace 0x627463))',
-                contractName: 'names',
-                contractAddress: 'SP000000000000000000002Q6VF78.bns',
-              },
-            },
-          ],
-          collection_id: 'SP000000000000000000002Q6VF78.bns',
-          collection_name: 'SP000000000000000000002Q6VF78.bns',
-          floor_price: 0,
-          total_nft: 1,
-        },
         'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys': {
           all_nfts: [
             {
@@ -209,14 +183,32 @@ describe('organizeNFTsIntoCollection', () => {
           collection_id: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           collection_name: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys',
           floor_price: 0,
-          total_nft: 1,
+        },
+        bns: {
+          all_nfts: [
+            {
+              asset_identifier: 'SP000000000000000000002Q6VF78.bns::names',
+              block_height: 30124,
+              tx_id: '0x0eadd48d421907991ba56bbdd707f77c67e341c3ababbc0290a3e0fcac006fac',
+              value: {
+                hex: '0x0c00000002046e616d65020000000464756c62096e616d6573706163650200000003627463',
+                repr: '(tuple (name 0x64756c62) (namespace 0x627463))',
+              },
+              identifier: {
+                tokenId: '(tuple (name 0x64756c62) (namespace 0x627463))',
+                contractName: 'names',
+                contractAddress: 'SP000000000000000000002Q6VF78.bns',
+              },
+            },
+          ],
+          collection_id: 'SP000000000000000000002Q6VF78.bns',
+          collection_name: 'BNS Names',
         },
       };
       expect(result).toStrictEqual(expected);
     });
 
     it('should return sorted all_nfts by tokenId', () => {
-      const collectionRecord = {};
       const nftArray: NonFungibleToken[] = [
         {
           asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
@@ -248,7 +240,7 @@ describe('organizeNFTsIntoCollection', () => {
         },
       ];
       const nftCollectionDataArray: NftCollectionData[] = [];
-      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+      const result = organizeNFTsIntoCollection(nftArray, nftCollectionDataArray);
 
       const expectedAllNfts = [
         {
@@ -285,7 +277,6 @@ describe('organizeNFTsIntoCollection', () => {
     });
 
     it('should return no duplicates', () => {
-      const collectionRecord = {};
       const nftArray: NonFungibleToken[] = [
         {
           asset_identifier: 'SP125J1ADVYWGWB9NQRCVGKYAG73R17ZNMV17XEJ7.mutant-monkeys::mutant-monkeys',
@@ -331,7 +322,7 @@ describe('organizeNFTsIntoCollection', () => {
         },
       ];
       const nftCollectionDataArray: NftCollectionData[] = [];
-      const result = organizeNFTsIntoCollection(collectionRecord, nftArray, nftCollectionDataArray);
+      const result = organizeNFTsIntoCollection(nftArray, nftCollectionDataArray);
 
       const expectedAllNfts = [
         {

--- a/types/api/stacks/assets.ts
+++ b/types/api/stacks/assets.ts
@@ -39,6 +39,7 @@ export type NonFungibleTokenApiResponse = {
   asset_identifier: string;
   value: NftIdValue;
   tx_id: string;
+  block_height: number;
 };
 
 export type NonFungibleTokenOld = NonFungibleTokenApiResponse & {


### PR DESCRIPTION
# 🔘 PR Type
- [x] Enhancement
- [x] Refactoring (no functional changes, no api changes)

# 📜 Background
issue: [eng-3268](https://linear.app/xverseapp/issue/ENG-3268/mitigate-hiro-api-is-returning-duplicate-holdings)

# 🔄 Changes

Does this PR introduce a breaking change?

- [x] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- refactor: organize nfts function to be pure, and move bns collection assignment in
- feat: remove thumbnail_nfts
- feat: sort and unique all_nfts for each collection
- added tests

Impact:


# 🖼 Screenshot / 📹 Video
before:
![image](https://github.com/secretkeylabs/xverse-core/assets/6109710/71edd409-8026-405d-b535-214ee02ba583)

after:
![image](https://github.com/secretkeylabs/xverse-core/assets/6109710/9e7ed043-1d0a-4871-a3e4-2a837092f90a)


# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
