### PR TITLE
fix: Get UTXO ordinal data in batches

### DIFF
--- a/api/ordinals/provider.ts
+++ b/api/ordinals/provider.ts
@@ -111,6 +111,19 @@ export default class OrdinalsApi implements OrdinalsApiProvider {
     }
   }
 
+  async getAllInscriptions(address: string): Promise<ordinalsType.Inscription[]> {
+    const firstPage = await this.getInscriptions(address, 0, 100);
+    const results = [...firstPage.results];
+
+    // we do this sequentially to avoid rate limiting
+    while (results.length < firstPage.total) {
+      const nextPage = await this.getInscriptions(address, results.length, firstPage.limit);
+      results.push(...nextPage.results);
+    }
+
+    return results;
+  }
+
   async getInscriptions(address: string, offset: number, limit: number): Promise<ordinalsType.InscriptionsList> {
     const url = 'inscriptions';
     const params = {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

When making payments from payments address, we only pick UTXOs that don't have inscriptions on them. We check the UTXOs by making a call to the backend one at a time. This leads to rate limits being hit.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- We get all the inscriptions for the address in batches and map them to the UTXOs instead

Impact:

- This fixes the rate limiting issue and should speed up the loading of the confirmation pages for users with many UTXOs in their payments address

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
