### PR TITLE
Fix ordinal in btc address detection

### DIFF
--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -807,8 +807,10 @@ export async function signOrdinalSendTransaction(
   // Make sure ordinal utxo is removed from utxo set used for fees
   // This can be true if ordinal utxo is from the payment address
 
+  const ordinalUtxoInPaymentAddress = unspentOutputs.some(
+    (u) => u.txid === ordinalUtxo.txid && u.vout === ordinalUtxo.vout,
+  );
   const filteredUnspentOutputs = filterUtxos(unspentOutputs, addressOrdinalsUtxos);
-  const ordinalUtxoInPaymentAddress = filteredUnspentOutputs.length < unspentOutputs.length;
 
   let feeRate: BtcFeeResponse = defaultFeeRate;
 


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

When sending an ordinal, we would detect if it is coming from the payments address and only sign with the payment address PK if that was the case. However, our detection logic would return true if there were any inscriptions in the payment address, not just the one we wanted to send.

This meant that if you were sending an ordinal and you happen to have another ordinal in your payments address, then we would sign the entire transaction with the payments PK, which would result in an invalid transaction.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- We now detect if the UTXO is actually coming from the payments address or not

Impact:

- We need to update core in the extension and mobile and do the following test:
  - Ensure you have an inscription in your btc address
  - try and send an ordinal from your ordinals address
  - in the confirmation page, change the fee
  - try and send

The above should fail in the current version of the extension but succeed with this version of core.

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
