### PR TITLE
Don't use dust UTXOs in txns

### DIFF
--- a/ledger/transaction.ts
+++ b/ledger/transaction.ts
@@ -53,9 +53,9 @@ export async function getTransactionData(
 
   let selectedUTXOs = selectUnspentOutputs(
     amountSats,
+    feeRateInput ? Number(feeRateInput) : feeRate.regular,
     filteredUnspentOutputs,
     ordinalUtxo,
-    feeRateInput ? Number(feeRateInput) : undefined,
   );
   let sumOfSelectedUTXOs = sumUnspentOutputs(selectedUTXOs);
 

--- a/tests/btc/transactions.test.ts
+++ b/tests/btc/transactions.test.ts
@@ -41,7 +41,7 @@ describe('UTXO selection', () => {
   it('selects UTXO of highest value first', () => {
     const testUtxos = [createUtxo(10000, true), createUtxo(20000, true)];
 
-    const utxos = selectUnspentOutputs(new BigNumber(10000), [...testUtxos], undefined, 22);
+    const utxos = selectUnspentOutputs(new BigNumber(10000), 22, [...testUtxos], undefined);
 
     expect(utxos.length).eq(1);
     expect(utxos[0]).toBe(testUtxos[1]);
@@ -50,7 +50,7 @@ describe('UTXO selection', () => {
   it('selects multiple UTXOs if needed', () => {
     const testUtxos = [createUtxo(10000, true), createUtxo(20000, true)];
 
-    const utxos = selectUnspentOutputs(new BigNumber(25000), [...testUtxos], undefined, 22);
+    const utxos = selectUnspentOutputs(new BigNumber(25000), 22, [...testUtxos], undefined);
 
     expect(utxos.length).eq(2);
     expect(utxos[0]).toBe(testUtxos[1]);
@@ -60,7 +60,7 @@ describe('UTXO selection', () => {
   it('deprioritises unconfirmed UTXOs', () => {
     const testUtxos = [createUtxo(10000, true), createUtxo(20000, true), createUtxo(30000, false)];
 
-    const utxos = selectUnspentOutputs(new BigNumber(10000), [...testUtxos], undefined, 22);
+    const utxos = selectUnspentOutputs(new BigNumber(10000), 22, [...testUtxos], undefined);
     expect(utxos.length).eq(1);
     expect(utxos[0]).toBe(testUtxos[1]);
   });
@@ -68,12 +68,12 @@ describe('UTXO selection', () => {
   it('Uses unconfirmed UTXOs if sats to send high enough', () => {
     const testUtxos = [createUtxo(10000, true), createUtxo(20000, true), createUtxo(30000, false)];
 
-    let utxos = selectUnspentOutputs(new BigNumber(30000), [...testUtxos], undefined, 22);
+    let utxos = selectUnspentOutputs(new BigNumber(30000), 22, [...testUtxos], undefined);
     expect(utxos.length).eq(2);
     expect(utxos[0]).toBe(testUtxos[1]);
     expect(utxos[1]).toBe(testUtxos[0]);
 
-    utxos = selectUnspentOutputs(new BigNumber(40000), [...testUtxos], undefined, 22);
+    utxos = selectUnspentOutputs(new BigNumber(40000), 22, [...testUtxos], undefined);
     expect(utxos.length).eq(3);
     expect(utxos[0]).toBe(testUtxos[1]);
     expect(utxos[1]).toBe(testUtxos[0]);
@@ -85,7 +85,7 @@ describe('UTXO selection', () => {
 
     // This should make the 10000 UTXO dust at the desired fee rate
     // as adding it would increase the fee by 10500 (more than the value of the UTXO)
-    const utxos = selectUnspentOutputs(new BigNumber(30000), [...testUtxos], undefined, 150);
+    const utxos = selectUnspentOutputs(new BigNumber(30000), 150, [...testUtxos], undefined);
     expect(utxos.length).eq(2);
     expect(utxos[0]).toBe(testUtxos[1]);
     expect(utxos[1]).toBe(testUtxos[2]);
@@ -462,7 +462,7 @@ describe('bitcoin transactions', () => {
 
     const feeRate = defaultFeeRate;
 
-    const selectedUnspentOutputs = selectUnspentOutputs(new BigNumber(satsToSend), utxos);
+    const selectedUnspentOutputs = selectUnspentOutputs(new BigNumber(satsToSend), feeRate.regular, utxos);
 
     const fee = await calculateFee(
       selectedUnspentOutputs,
@@ -841,6 +841,7 @@ describe('bitcoin transactions', () => {
 
     const selectedUnspentOutputs = selectUnspentOutputs(
       new BigNumber(ordinalOutputs[0].value),
+      feeRate.regular,
       filteredUnspentOutputs,
       ordinalOutputs[0],
     );

--- a/transactions/btc.ts
+++ b/transactions/btc.ts
@@ -16,10 +16,10 @@ const MINIMUM_CHANGE_OUTPUT_SATS = 1000;
 export const defaultFeeRate = {
   limits: {
     min: 5,
-    max: 10,
+    max: 50,
   },
-  regular: 5,
-  priority: 10,
+  regular: 12,
+  priority: 20,
 };
 
 export interface Recipient {
@@ -55,9 +55,9 @@ export async function isCustomFeesAllowed(network: NetworkType, customFees: stri
 
 export function selectUnspentOutputs(
   amountSats: BigNumber,
+  feeRate: number,
   unspentOutputs: Array<UTXO>,
   pinnedOutput?: UTXO,
-  feeRate?: number,
 ): Array<UTXO> {
   const inputs: Array<UTXO> = [];
   let sumValue = 0;
@@ -309,7 +309,7 @@ export async function getFee(
     const newSatsToSend = satsToSend.plus(calculatedFee);
 
     // Select unspent outputs
-    iSelectedUnspentOutputs = selectUnspentOutputs(newSatsToSend, unspentOutputs, pinnedOutput, selectedFeeRate);
+    iSelectedUnspentOutputs = selectUnspentOutputs(newSatsToSend, selectedFeeRate, unspentOutputs, pinnedOutput);
     sumSelectedOutputs = sumUnspentOutputs(iSelectedUnspentOutputs);
 
     // Check if select output count has changed since last iteration
@@ -396,9 +396,9 @@ export async function getBtcFees(
     // Select unspent outputs
     const selectedUnspentOutputs = selectUnspentOutputs(
       satsToSend,
+      feeRateInput ? Number(feeRateInput) : feeRate.regular,
       unspentOutputs,
       undefined,
-      feeRateInput ? Number(feeRateInput) : undefined,
     );
     const sumSelectedOutputs = sumUnspentOutputs(selectedUnspentOutputs);
 
@@ -468,9 +468,9 @@ export async function getBtcFeesForOrdinalSend(
     // Select unspent outputs
     const selectedUnspentOutputs = selectUnspentOutputs(
       satsToSend,
+      feeRateInput ? Number(feeRateInput) : feeRate.regular,
       filteredUnspentOutputs,
       ordinalUtxo,
-      feeRateInput ? Number(feeRateInput) : undefined,
     );
 
     const sumSelectedOutputs = sumUnspentOutputs(selectedUnspentOutputs);
@@ -742,7 +742,12 @@ export async function signBtcTransaction(
     });
 
     // Select unspent outputs
-    let selectedUnspentOutputs = selectUnspentOutputs(satsToSend, unspentOutputs);
+    let selectedUnspentOutputs = selectUnspentOutputs(
+      satsToSend,
+      // TODO: refactor this to use actual desired fee rate
+      feeRate.regular,
+      unspentOutputs,
+    );
     const sumSelectedOutputs = sumUnspentOutputs(selectedUnspentOutputs);
 
     if (sumSelectedOutputs.isLessThan(satsToSend)) {
@@ -845,7 +850,13 @@ export async function signOrdinalSendTransaction(
   let satsToSend = fee ? fee.plus(new BigNumber(ordinalUtxo.value)) : new BigNumber(ordinalUtxo.value);
 
   // Select unspent outputs
-  let selectedUnspentOutputs = selectUnspentOutputs(satsToSend, filteredUnspentOutputs, ordinalUtxo);
+  let selectedUnspentOutputs = selectUnspentOutputs(
+    satsToSend,
+    // TODO: refactor this to use actual desired fee rate
+    feeRate.regular,
+    filteredUnspentOutputs,
+    ordinalUtxo,
+  );
 
   const sumSelectedOutputs = sumUnspentOutputs(selectedUnspentOutputs);
 

--- a/transactions/inscriptionMint.ts
+++ b/transactions/inscriptionMint.ts
@@ -141,6 +141,7 @@ export async function inscriptionMintFeeEstimate(estimateProps: EstimateProps): 
     availableUtxos: addressUtxos,
     feeRate,
     network,
+    useUnconfirmed: false,
   });
 
   if (!bestUtxoData) {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

We were using confirmed Dust UTXOs as inputs for txns before unconfirmed large UTXOs (e.g. change).

Additionally, we weren't filtering out unconfirmed UTXOs when selecting them for inscription commit txns, so the fee estimate logic was using different logic to the final commit txn build logic causing inconsistencies.

# 🔄 Changes

Does this PR introduce a breaking change?

- [x] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- When selecting UTXOs, if a fee rate has not been specified, we use the regular fee rate to filter out dust UTXOs

Impact:

- We would no longer use dust UTXOs for txns

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
