### PR TITLE
Use custom url for electrs api

### DIFF
--- a/account/index.ts
+++ b/account/index.ts
@@ -1,6 +1,7 @@
-import { StacksMainnet, StacksNetwork } from '@stacks/network';
+import { StacksNetwork } from '@stacks/network';
 import * as bip39 from 'bip39';
 import { fetchBtcTransactionsData, getBnsName, getConfirmedTransactions } from '../api';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import {
   connectToGaiaHubWithConfig,
   createWalletGaiaConfig,
@@ -9,7 +10,7 @@ import {
   getOrCreateWalletConfig,
   updateWalletConfig,
 } from '../gaia';
-import { Account, BtcTransactionData, NetworkType, SettingsNetwork, StxTransactionListData } from '../types';
+import { Account, BtcTransactionData, SettingsNetwork, StxTransactionListData } from '../types';
 import { BIP32Interface, bip32 } from '../utils/bip32';
 import { getWalletFromRootNode, walletFromSeedPhrase } from '../wallet';
 import { GAIA_HUB_URL } from './../constant';
@@ -59,17 +60,17 @@ export async function checkAccountActivity(
   btcAddress: string,
   ordinalsAddress: string,
   selectedNetwork: StacksNetwork,
+  esploraProvider: EsploraApiProvider,
 ) {
   const stxTxHistory: StxTransactionListData = await getConfirmedTransactions({
     stxAddress,
     network: selectedNetwork,
   });
   if (stxTxHistory.totalCount !== 0) return true;
-  const networkType: NetworkType = selectedNetwork === new StacksMainnet() ? 'Mainnet' : 'Testnet';
   const btcTxHistory: BtcTransactionData[] = await fetchBtcTransactionsData(
     btcAddress,
     ordinalsAddress,
-    networkType,
+    esploraProvider,
     true,
   );
   return btcTxHistory.length !== 0;

--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -105,5 +105,10 @@ export class BitcoinEsploraApiProvider extends ApiInstance implements BitcoinApi
     const data = await this.httpGet<number>('/blocks/tip/height');
     return data;
   }
+
+  async getLatestBlockHash(height: number): Promise<string> {
+    const data = await this.httpGet<string>(`/block-height/${height}`);
+    return data;
+  }
 }
 export default BitcoinEsploraApiProvider;

--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -17,7 +17,7 @@ export class BitcoinEsploraApiProvider extends ApiInstance implements BitcoinApi
 
   constructor(options: EsploraApiProviderOptions) {
     const { url, network } = options;
-    const baseURL = url || network === 'Mainnet' ? BTC_BASE_URI_MAINNET : BTC_BASE_URI_TESTNET;
+    const baseURL = url || (network === 'Mainnet' ? BTC_BASE_URI_MAINNET : BTC_BASE_URI_TESTNET);
 
     super({ baseURL });
 

--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -106,7 +106,7 @@ export class BitcoinEsploraApiProvider extends ApiInstance implements BitcoinApi
     return data;
   }
 
-  async getLatestBlockHash(height: number): Promise<string> {
+  async getBlockHash(height: number): Promise<string> {
     const data = await this.httpGet<string>(`/block-height/${height}`);
     return data;
   }

--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import XordApiProvider from '../api/ordinals/provider';
 import { INSCRIPTION_REQUESTS_SERVICE_URL, ORDINALS_URL, XVERSE_API_BASE_URL, XVERSE_INSCRIBE_URL } from '../constant';
 import {
@@ -54,16 +54,17 @@ const sortOrdinalsByConfirmationTime = (prev: BtcOrdinal, next: BtcOrdinal) => {
   return 0;
 };
 
-export async function fetchBtcOrdinalsData(btcAddress: string, network: NetworkType): Promise<BtcOrdinal[]> {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
+export async function fetchBtcOrdinalsData(
+  btcAddress: string,
+  esploraProvider: EsploraApiProvider,
+  network: NetworkType,
+): Promise<BtcOrdinal[]> {
   const xordClient = new XordApiProvider({
     network,
   });
 
   const [addressUTXOs, inscriptions] = await Promise.all([
-    btcClient.getUnspentUtxos(btcAddress),
+    esploraProvider.getUnspentUtxos(btcAddress),
     xordClient.getAllInscriptions(btcAddress),
   ]);
   const ordinals: BtcOrdinal[] = [];
@@ -117,11 +118,12 @@ export async function getTextOrdinalContent(network: NetworkType, inscriptionId:
     });
 }
 
-export async function getNonOrdinalUtxo(address: string, network: NetworkType): Promise<Array<UTXO>> {
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const unspentOutputs = await btcClient.getUnspentUtxos(address);
+export async function getNonOrdinalUtxo(
+  address: string,
+  esploraProvider: EsploraApiProvider,
+  network: NetworkType,
+): Promise<Array<UTXO>> {
+  const unspentOutputs = await esploraProvider.getUnspentUtxos(address);
   const nonOrdinalOutputs: Array<UTXO> = [];
 
   for (let i = 0; i < unspentOutputs.length; i++) {

--- a/api/xverse.ts
+++ b/api/xverse.ts
@@ -1,6 +1,7 @@
 import { StacksTransaction } from '@stacks/transactions';
 import axios, { AxiosResponse } from 'axios';
 import BigNumber from 'bignumber.js';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import { API_TIMEOUT_MILLI, XVERSE_API_BASE_URL, XVERSE_SPONSOR_URL } from '../constant';
 import {
   AppInfo,
@@ -202,8 +203,12 @@ export async function getSponsorInfo(sponsorHost?: string): Promise<boolean> {
     .catch(handleAxiosError);
 }
 
-export async function getOrdinalsByAddress(network: NetworkType, ordinalsAddress: string) {
-  return fetchBtcOrdinalsData(ordinalsAddress, network);
+export async function getOrdinalsByAddress(
+  esploraProvider: EsploraApiProvider,
+  network: NetworkType,
+  ordinalsAddress: string,
+) {
+  return fetchBtcOrdinalsData(ordinalsAddress, esploraProvider, network);
 }
 
 export async function getOrdinalInfo(network: NetworkType, ordinalId: string): Promise<OrdinalInfo> {

--- a/ledger/transaction.ts
+++ b/ledger/transaction.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import BigNumber from 'bignumber.js';
 import { Psbt, networks } from 'bitcoinjs-lib';
 import { fetchBtcFeeRate } from '../api';
-import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import {
   Recipient,
   defaultFeeRate,
@@ -26,6 +26,7 @@ import { Bip32Derivation, TapBip32Derivation } from './types';
  * @returns the selected utxos, the change value and the fee
  * */
 export async function getTransactionData(
+  esploraProvider: EsploraApiProvider,
   network: NetworkType,
   senderAddress: string,
   recipients: Array<Recipient>,
@@ -33,10 +34,7 @@ export async function getTransactionData(
   ordinalUtxo?: UTXO,
 ) {
   // Get sender address unspent outputs
-  const btcClient = new BitcoinEsploraApiProvider({
-    network,
-  });
-  const unspentOutputs: UTXO[] = await btcClient.getUnspentUtxos(senderAddress);
+  const unspentOutputs: UTXO[] = await esploraProvider.getUnspentUtxos(senderAddress);
 
   let filteredUnspentOutputs = unspentOutputs;
 

--- a/tests/transactions/rbf.data.ts
+++ b/tests/transactions/rbf.data.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import EsploraApiProvider from '../../api/esplora/esploraAPiProvider';
 import { RBFProps } from '../../transactions/rbf';
 import { BtcTransactionData, Transaction, UTXO } from '../../types';
 
@@ -253,7 +254,7 @@ export const rbfEsploraTransaction: Transaction = {
   ],
 };
 
-export const wallet: RBFProps = {
+export const constructOptions = (esploraProvider?: EsploraApiProvider): RBFProps => ({
   btcAddress: '32A81f7NmkRBq5pYBxGbR989pX3rmSedxr',
   btcPublicKey: '032215d812282c0792c8535c3702cca994f5e3da9cd8502c3e190d422f0066fdff',
   ordinalsAddress: 'bc1pr09enf3yc43cz8qh7xwaasuv3xzlgfttdr3wn0q2dy9frkhrpdtsk05jqq',
@@ -262,9 +263,10 @@ export const wallet: RBFProps = {
     getSeed: () => 'seed',
   } as any,
   accountId: 0,
+  esploraProvider: esploraProvider || ({} as any),
   network: 'Mainnet',
   accountType: 'software',
-};
+});
 
 export const largeUtxo: UTXO = {
   txid: 'bb01711d83a22efcb10a8f025d17e61a09a53fafb22c4faf831df0cbdf104b40',

--- a/transactions/brc20.ts
+++ b/transactions/brc20.ts
@@ -3,7 +3,7 @@ import { CancelToken } from 'axios';
 import BigNumber from 'bignumber.js';
 
 import { createInscriptionRequest } from '../api';
-import BitcoinEsploraApiProvider from '../api/esplora/esploraAPiProvider';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import xverseInscribeApi from '../api/xverseInscribe';
 import { NetworkType, UTXO } from '../types';
 import { CoreError } from '../utils/coreError';
@@ -74,16 +74,17 @@ const createTransferInscriptionContent = (token: string, amount: string) => ({
   amt: amount,
 });
 
-const btcClient = new BitcoinEsploraApiProvider({
-  network: 'Mainnet',
-});
-
 // TODO: deprecate
-export const createBrc20TransferOrder = async (token: string, amount: string, recipientAddress: string) => {
+export const createBrc20TransferOrder = async (
+  token: string,
+  amount: string,
+  recipientAddress: string,
+  esploraAPiProvider: EsploraApiProvider,
+) => {
   const transferInscriptionContent = createTransferInscriptionContent(token, amount);
   const contentB64 = base64.encode(Buffer.from(JSON.stringify(transferInscriptionContent)));
   const contentSize = Buffer.from(JSON.stringify(transferInscriptionContent)).length;
-  const feesResponse = await btcClient.getRecommendedFees();
+  const feesResponse = await esploraAPiProvider.getRecommendedFees();
   const inscriptionRequest = await createInscriptionRequest(
     recipientAddress,
     contentSize,

--- a/transactions/btc.utils.ts
+++ b/transactions/btc.utils.ts
@@ -2,6 +2,7 @@ import { hex } from '@scure/base';
 import BigNumber from 'bignumber.js';
 
 import { getOrdinalsByAddress } from '../api';
+import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import { NetworkType, UTXO } from '../types';
 import type { Recipient, TransactionUtxoSelectionMetadata } from './btc';
 import { createTransaction } from './btc';
@@ -217,7 +218,7 @@ export function selectOptimalUtxos({
 }
 
 // get ordinals utxos in btc address
-export async function getOrdinalsUtxos(network: NetworkType, btcAddress: string) {
-  const ordinals = await getOrdinalsByAddress(network, btcAddress);
+export async function getOrdinalsUtxos(esploraProvider: EsploraApiProvider, network: NetworkType, btcAddress: string) {
+  const ordinals = await getOrdinalsByAddress(esploraProvider, network, btcAddress);
   return ordinals.map((item) => item.utxo);
 }


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background

Currently, when changing the electrs URL in the apps, we don't use the custom URL for most functions. This ensures that all the places that use the URL have the api provider injected instead of being created in place, allowing the injection of a provider with a custom URL. 

# 🔄 Changes

Does this PR introduce a breaking change?

- [x] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- All functions that created their own instance of the Esplora API Provider now accept it as an argument instead.

Impact:

- We will need to change the web extension and mobile apps to inject the provider in all the changed functions.

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
