### PR TITLE
chore: add address data function in esplora provider

### DIFF
--- a/api/esplora/esploraAPiProvider.ts
+++ b/api/esplora/esploraAPiProvider.ts
@@ -42,6 +42,11 @@ export class BitcoinEsploraApiProvider extends ApiInstance implements BitcoinApi
     };
   }
 
+  async getAddressData(address: string) {
+    const data = await this.httpGet<BtcAddressBalanceResponse>(`/address/${address}`);
+    return data;
+  }
+
   async getUnspentUtxos(address: string): Promise<(esplora.UTXO & { address: string; blockHeight?: number })[]> {
     const data = await this.httpGet<esplora.UTXO[]>(`/address/${address}/utxo`);
 

--- a/api/esplora/types.ts
+++ b/api/esplora/types.ts
@@ -1,4 +1,5 @@
 import { BtcAddressData, BtcTransactionBroadcastResponse } from '../../types';
+import { BtcAddressBalanceResponse } from '../../types/api/blockcypher/wallet';
 import { BtcAddressMempool, Transaction, UTXO } from '../../types/api/esplora';
 export interface BitcoinApiProvider {
   /**
@@ -7,6 +8,12 @@ export interface BitcoinApiProvider {
    * @return {Promise<BtcAddressData>}
    */
   getBalance(address: string): Promise<BtcAddressData>;
+
+  /**
+   * Get the address data return from the API of a given address
+   * @param {string} address
+   */
+  getAddressData(address: string): Promise<BtcAddressBalanceResponse>;
   /**
    * Get The unspent utxos of a given Address
    * @param {string} address


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background

We should implement a function that retrieves payload data from the Bitcoin address data API. This will enable us to perform various calculations on the front-end, such as determining the balance of confirmed UTXOs.

Issue Link: [ENG-3385](https://linear.app/xverseapp/issue/ENG-3385/[ext-%F0%9F%8C%8D]-inform-users-that-they-dont-have-enough-confirmed-funds-to)

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- added function `getAddressData` in `esploraApiProvider.ts`
- no breaking changes

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
