### PR TITLE
Add inputs to sign arg to PSBT logic

### DIFF
--- a/transactions/bitcoin/enhancedPsbt.ts
+++ b/transactions/bitcoin/enhancedPsbt.ts
@@ -45,12 +45,13 @@ export class EnhancedPsbt {
 
           this._inputsToSignMap[inputIndex].push({ address: input.address, sigHash: input.sigHash });
 
-          if (!input.sigHash || (input.sigHash | btc.SigHash.ALL) !== btc.SigHash.ALL) {
+          if (!input.sigHash) {
             continue;
           }
 
           if ((input.sigHash | btc.SigHash.SINGLE) === btc.SigHash.SINGLE) {
             isSigHashAll = false;
+            continue;
           }
 
           if ((input.sigHash | btc.SigHash.NONE) === btc.SigHash.NONE) {


### PR DESCRIPTION
TODO: Unit testing

# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
The new PSBT logic ignored the inputs to sign arg from sats connect. It actually needs to process them in case of a multisig scenario where we cannot match the inputs witness script to the pub key.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- The inputs to sign arg is no longer ignored

To test:
- Use this file in this branch in the sats-connect example app: https://github.com/secretkeylabs/sats-connect-example/blob/victor/aproot-example/src/components/taprootPsbt.tsx
- Try and go through the flow in that component
- The prior consolidated PSBT logic should fail while the new one should succeed

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
