### PR TITLE
refactor: move the applyFeeMultipliers function to core

### DIFF
--- a/connect/transactionRequest.test.ts
+++ b/connect/transactionRequest.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { stxFeeReducer } from './transactionRequest';
+import { AppInfo } from '../types';
+
+describe('stxFeeReducer', () => {
+  [
+    {
+      name: 'returns initialFee when no appInfo',
+      inputs: { initialFee: BigInt(3), appInfo: null },
+      expectedFee: BigInt(3),
+    },
+    {
+      name: 'returns initialFee when no send multiplier and no threshold',
+      inputs: {
+        initialFee: BigInt(3),
+        appInfo: {
+          stxSendTxMultiplier: undefined,
+          thresholdHighStacksFee: undefined,
+        } as unknown as AppInfo,
+      },
+      expectedFee: BigInt(3),
+    },
+    {
+      name: 'returns fee with multiplier applied if under threshold',
+      inputs: {
+        initialFee: BigInt(1),
+        appInfo: {
+          stxSendTxMultiplier: 3,
+          thresholdHighStacksFee: 6,
+        } as unknown as AppInfo,
+      },
+      expectedFee: BigInt(3),
+    },
+    {
+      name: 'returns intialFee unmodified if multiplier is not an integer',
+      inputs: {
+        initialFee: BigInt(1),
+        appInfo: {
+          stxSendTxMultiplier: 0.5,
+          thresholdHighStacksFee: 6,
+        } as unknown as AppInfo,
+      },
+      expectedFee: BigInt(1),
+    },
+    {
+      name: 'returns threshold fee if initialFee is higher',
+      inputs: {
+        initialFee: BigInt(10),
+        appInfo: {
+          stxSendTxMultiplier: 1,
+          thresholdHighStacksFee: 6,
+        } as unknown as AppInfo,
+      },
+      expectedFee: BigInt(6),
+    },
+    {
+      name: 'returns threshold fee if fee after multiplier is higher',
+      inputs: {
+        initialFee: BigInt(2),
+        appInfo: {
+          stxSendTxMultiplier: 4,
+          thresholdHighStacksFee: 6,
+        } as unknown as AppInfo,
+      },
+      expectedFee: BigInt(6),
+    },
+  ].forEach(({ name, inputs, expectedFee }) => {
+    it(name, () => {
+      expect(stxFeeReducer(inputs)).toEqual(expectedFee);
+    });
+  });
+});


### PR DESCRIPTION
# 🔘 PR Type
- [x] Refactoring (no functional changes, no api changes)
- [x] Feature

# 📜 Background
https://linear.app/xverseapp/issue/ENG-3458/stx-fees-are-not-being-estimated

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:
- move the apply fee multiplier function to core after merging in changes from stx tx hex signing
- add unit tests for fee multiplier/threshold logic

Impact:
- stx token transfers will have fees capped at the thresholdHighStacksFees amount

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist

Please ensure the following are true before merging:

- [x] Code Style is consistent with the project guidelines.
- [x] Code is readable and well-commented.
- [x] No unnecessary or debugging code has been added.
- [x] Security considerations have been taken into account.
- [x] The change has been manually tested and works as expected.
- [x] Breaking changes and their impacts have been considered and documented.
- [x] Code does not introduce new technical debt or issues.
