### PR TITLE
fix bitwise ops

### DIFF
--- a/transactions/bitcoin/enhancedPsbt.ts
+++ b/transactions/bitcoin/enhancedPsbt.ts
@@ -49,12 +49,12 @@ export class EnhancedPsbt {
             continue;
           }
 
-          if ((input.sigHash | btc.SigHash.SINGLE) === btc.SigHash.SINGLE) {
+          if ((input.sigHash & btc.SigHash.SINGLE) === btc.SigHash.SINGLE) {
             isSigHashAll = false;
             continue;
           }
 
-          if ((input.sigHash | btc.SigHash.NONE) === btc.SigHash.NONE) {
+          if ((input.sigHash & btc.SigHash.NONE) === btc.SigHash.NONE) {
             hasSigHashNone = true;
             isSigHashAll = false;
           }
@@ -123,10 +123,10 @@ export class EnhancedPsbt {
 
       // sig hash single value is 3 while sighash none is 2 and sighash all is 1, so we need to ensure we
       // don't have a single before we do the bitwise or for all and none
-      const isSigHashSingle = (sigHash && sigHash | btc.SigHash.SINGLE) === btc.SigHash.SINGLE;
+      const isSigHashSingle = (sigHash && sigHash & btc.SigHash.SINGLE) === btc.SigHash.SINGLE;
 
       isSigHashAll =
-        isSigHashAll && !isSigHashSingle && (sigHash === undefined || (sigHash | btc.SigHash.ALL) === btc.SigHash.ALL);
+        isSigHashAll && !isSigHashSingle && (sigHash === undefined || (sigHash & btc.SigHash.ALL) === btc.SigHash.ALL);
       hasSigHashNone =
         hasSigHashNone || (!isSigHashSingle && (sigHash && sigHash & btc.SigHash.NONE) === btc.SigHash.NONE);
     }


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
SigHash calcs were incorrect due to using bitwise OR instead of AND, resulting in the wrong data being shown on the extension PSBT signing screen.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)


# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
