### PR TITLE
Update the RbfTransaction class constructor

### DIFF
--- a/transactions/rbf.ts
+++ b/transactions/rbf.ts
@@ -283,7 +283,7 @@ class RbfTransaction {
 
   private signTxSoftware = async (transaction: btc.Transaction, options?: CompileOptions): Promise<btc.Transaction> => {
     if (!options?.getSeedPhrase) {
-      throw new Error('Options are required for non-dummy transactions');
+      throw new Error('getSeedPhrase option is required to sign the transaction');
     }
 
     const tx = btc.Transaction.fromPSBT(transaction.toPSBT(0));


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Enhancement

# 📜 Background

We use the `getSeedPhrase` function to sign the transaction, so there is no need to ask for it in the RbfTransaction constructor, it would make more sense to pass it to the signing function. Also, this change would enable a better UX for the mobile app since we won't need to ask the user to enter a password when they just enter the Speed Up tx screen, instead, they'll have to enter the password only when they sign the RBF tx.

Issue Link: #[[ENG-3379](https://linear.app/xverseapp/issue/ENG-3379/make-ui-for-rbf-in-mobile-app)]
Context Link (if applicable):

# 🔄 Changes

Does this PR introduce a breaking change?

- [x] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- The breaking change here is that the `getSeedPhrase` function is now being passed to the `getReplacementTransaction` method of the `RbfTransaction` class instead of its' constructor.

Impact:

- This change impacts the RBF functionality for both mobile and web-extension, so we should adjust the code there.

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
