### PR TITLE
Remove ledger fields from final PSBT

### DIFF
--- a/transactions/bitcoin/context.ts
+++ b/transactions/bitcoin/context.ts
@@ -405,6 +405,7 @@ export class LedgerP2wpkhAddressContext extends P2wpkhAddressContext {
     for (const signature of signatures) {
       transaction.updateInput(signature[0], {
         partialSig: [[signature[1].pubkey, signature[1].signature]],
+        bip32Derivation: undefined,
       });
     }
   }
@@ -567,6 +568,7 @@ export class LedgerP2trAddressContext extends P2trAddressContext {
     for (const signature of signatures) {
       transaction.updateInput(signature[0], {
         tapKeySig: signature[1].signature,
+        bip32Derivation: undefined,
       });
     }
   }


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

Ledger requires bip32 derivation definition in order to know which inputs to sign. We add this into incoming PSBTs, but we don't remove it afterward, which causes an issue on Unisat as they use bitcoinlib-js which marks the input as an invalid taproot input as it has the field populated. 

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- The bip32 derivation is cleared after signing

Impact:

- This should fix listing on Unisat
- Requires an update on extension and mobile apps

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
