### PR TITLE
Don't remove bip32 derivation for ledger p2wpkh address after sign - ENG-3666

### DIFF
--- a/transactions/bitcoin/context.ts
+++ b/transactions/bitcoin/context.ts
@@ -13,9 +13,9 @@ import { type NetworkType, type UTXO } from '../../types';
 import { bip32 } from '../../utils/bip32';
 import { getBitcoinDerivationPath, getSegwitDerivationPath, getTaprootDerivationPath } from '../../wallet';
 import { InputToSign } from '../psbt';
+import { ExtendedUtxo } from './extendedUtxo';
 import { CompilationOptions, SupportedAddressType } from './types';
 import { areByteArraysEqual } from './utils';
-import { ExtendedUtxo } from './extendedUtxo';
 
 export type SignOptions = {
   ledgerTransport?: Transport;
@@ -405,7 +405,6 @@ export class LedgerP2wpkhAddressContext extends P2wpkhAddressContext {
     for (const signature of signatures) {
       transaction.updateInput(signature[0], {
         partialSig: [[signature[1].pubkey, signature[1].signature]],
-        bip32Derivation: undefined,
       });
     }
   }


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

# 📜 Background
The bip32 derivation is set for ledger accounts for ledger to know which inputs to sign. We remove it for the taproot inputs, but it needs to stay for the p2wpkh inputs as it forms part of the signature.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- We no longer remove the bip32 derivation for p2wpkh inputs

Impact:

- This should fix magisat purchases for ledger and Unisat listing and purchases should still work.

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
