### PR TITLE
Make some small refactoring related to variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,15 @@
         "code": 120
       }
     ],
-    "@typescript-eslint/no-loop-func": "off"
+    "@typescript-eslint/no-loop-func": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "args": "after-used",
+        "ignoreRestSiblings": true,
+        "argsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/api/gamma.ts
+++ b/api/gamma.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { GAMMA_COLLECTION_API, NFT_BASE_URI } from '../constant';
+import { API_TIMEOUT_MILLI, GAMMA_COLLECTION_API, NFT_BASE_URI } from '../constant';
 import { NftCollectionData, NftDetailResponse } from '../types';
 
 export async function getNftDetail(
@@ -11,7 +11,7 @@ export async function getNftDetail(
 
   return axios
     .get<NftDetailResponse>(apiUrl, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     })
     .then((response) => {
       return response.data;
@@ -26,7 +26,7 @@ export async function getNftsCollectionData(collectionId: string): Promise<NftCo
     const apiUrl = `${GAMMA_COLLECTION_API}/${collectionId}?include=floorItem`;
 
     const response = await axios.get<NftCollectionData>(apiUrl, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     });
 
     return response.data;

--- a/api/ordinals.ts
+++ b/api/ordinals.ts
@@ -1,7 +1,13 @@
 import axios, { isAxiosError } from 'axios';
 import EsploraApiProvider from '../api/esplora/esploraAPiProvider';
 import { OrdinalsApi } from '../api/ordinals/provider';
-import { INSCRIPTION_REQUESTS_SERVICE_URL, ORDINALS_URL, XVERSE_API_BASE_URL, XVERSE_INSCRIBE_URL } from '../constant';
+import {
+  API_TIMEOUT_MILLI,
+  INSCRIPTION_REQUESTS_SERVICE_URL,
+  ORDINALS_URL,
+  XVERSE_API_BASE_URL,
+  XVERSE_INSCRIBE_URL,
+} from '../constant';
 import {
   Account,
   AddressBundleResponse,
@@ -106,7 +112,7 @@ export async function getTextOrdinalContent(network: NetworkType, inscriptionId:
   const url = ORDINALS_URL(network, inscriptionId);
   return axios
     .get<string>(url, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
       transformResponse: [(data) => parseOrdinalTextContentData(data)],
     })
     .then((response) => response!.data)
@@ -137,7 +143,7 @@ export async function getOrdinalsFtBalance(network: NetworkType, address: string
   const url = `${XVERSE_API_BASE_URL(network)}/v1/ordinals/token/balances/${address}`;
   return axios
     .get(url, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     })
     .then((response) => {
       if (response.data) {
@@ -180,7 +186,7 @@ export async function getBrc20History(
   const url = `${XVERSE_API_BASE_URL(network)}/v1/ordinals/token/${token}/history/${address}`;
   return axios
     .get(url, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     })
     .then((response) => {
       const data: HiroApiBrc20TxHistoryResponse = response.data;

--- a/api/stacks.ts
+++ b/api/stacks.ts
@@ -217,7 +217,7 @@ export async function getFtData(stxAddress: string, network: StacksNetwork): Pro
   const apiUrl = `${getNetworkURL(network)}/extended/v1/address/${stxAddress}/balances`;
 
   const response = await axios.get<TokensResponse>(apiUrl, {
-    timeout: 30000,
+    timeout: API_TIMEOUT_MILLI,
   });
 
   const tokens: FungibleToken[] = [];
@@ -244,7 +244,7 @@ export async function getAccountAssets(stxAddress: string, network: StacksNetwor
 
   return axios
     .get<TokensResponse>(apiUrl, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     })
     .then((response) => {
       const assets: NonFungibleToken[] = [];
@@ -311,7 +311,7 @@ export async function getContractInterface(
     const apiUrl = `${getNetworkURL(network)}/v2/contracts/interface/${contractAddress}/${contractName}`;
 
     const response = await axios.get<ContractInterfaceResponse>(apiUrl, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     });
 
     return response.data;
@@ -324,7 +324,7 @@ export async function getBnsName(stxAddress: string, network: StacksNetwork) {
   try {
     const apiUrl = `${getNetworkURL(network)}/v1/addresses/stacks/${stxAddress}`;
     const response = await axios.get<AddressToBnsResponse>(apiUrl, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     });
     return response?.data?.names[0];
   } catch (err) {
@@ -413,7 +413,7 @@ export async function getStacksInfo(network: string) {
   try {
     const url = `${network}/v2/info`;
     const response = await axios.get<CoreInfo>(url, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     });
     return response?.data;
   } catch (err) {
@@ -466,7 +466,7 @@ export async function fetchDelegationState(stxAddress: string, network: StacksNe
 export async function fetchCoinMetaData(contract: string, network: StacksNetwork) {
   try {
     const response = await axios.get<CoinMetaData>(`${getNetworkURL(network)}/metadata/ft/${contract}`, {
-      timeout: 30000,
+      timeout: API_TIMEOUT_MILLI,
     });
     return response?.data;
   } catch (err) {


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)

# 📜 Background

I noticed that we currently don't have the `@typescript-eslint/no-unused-vars` eslint rule enabled and that we still have the hardcoded the request timeout value instead of using the constant, so this PR is here to address those things.

Issue Link: #[issue_number]
Context Link (if applicable):

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- This PR enables the `@typescript-eslint/no-unused-vars` eslint rule to show the warnings for the unused vars/imports
- It also changes the requests timeout value from `30000` to `API_TIMEOUT_MILLI` constant which has the same value

Impact:

- This PR doesn't change any logic, it only improves the codebase and developer experience

# 🖼 Screenshot / 📹 Video

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
