### PR TITLE
Refactor sighash all calc for PSBTs

### DIFF
--- a/transactions/bitcoin/enhancedPsbt.ts
+++ b/transactions/bitcoin/enhancedPsbt.ts
@@ -48,7 +48,7 @@ export class EnhancedPsbt {
 
           this._inputsToSignMap[inputIndex].push({ address: input.address, sigHash: input.sigHash });
 
-          if (!input.sigHash) {
+          if (!input.sigHash || (input.sigHash & btc.SigHash.SINGLE) === btc.SigHash.SINGLE) {
             continue;
           }
 


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background

We were incorrectly detecting if a PSBT is sighash all or not.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- Calculation of PSBT sighash

impact:
- This requires a new version of core and an update into the extension and mobile.
- The sign PSBT screen should show incoming inscriptions on marketplaces

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
