### PR TITLE
Remove nonwitnessutxo injection on pre-sign input preparation

### DIFF
--- a/transactions/bitcoin/context.ts
+++ b/transactions/bitcoin/context.ts
@@ -198,37 +198,6 @@ export abstract class AddressContext {
     // this can be implemented by subclasses if they need to do something before signing
   }
 
-  protected async addNonWitnessUtxosToInputs(
-    transaction: btc.Transaction,
-    options: SignOptions,
-    witnessScript?: Uint8Array,
-  ): Promise<void> {
-    const signIndexes = this.getSignIndexes(transaction, options, witnessScript);
-
-    for (const i of Object.keys(signIndexes)) {
-      const input = transaction.getInput(+i);
-      if (!input.txid?.length) {
-        continue;
-      }
-
-      const txId = hex.encode(input.txid);
-
-      let utxo = await this.getUtxo(`${txId}:${input.index}`);
-
-      if (!utxo) {
-        utxo = await this.getExternalUtxo(`${txId}:${input.index}`);
-      }
-
-      if (utxo) {
-        const nonWitnessUtxo = Buffer.from(await utxo.hex, 'hex');
-        transaction.updateInput(+i, {
-          nonWitnessUtxo,
-          // witnessUtxo: undefined, // TODO: this should be removed for non-segwit inputs
-        });
-      }
-    }
-  }
-
   protected abstract getDerivationPath(): string;
   abstract addInput(transaction: btc.Transaction, utxo: ExtendedUtxo, options?: CompilationOptions): Promise<void>;
   abstract signInputs(transaction: btc.Transaction, options: SignOptions): Promise<void>;
@@ -377,13 +346,21 @@ export class P2wpkhAddressContext extends AddressContext {
 }
 
 export class LedgerP2wpkhAddressContext extends P2wpkhAddressContext {
+  async addInput(transaction: btc.Transaction, extendedUtxo: ExtendedUtxo, options?: CompilationOptions) {
+    super.addInput(transaction, extendedUtxo, options);
+
+    const nonWitnessUtxo = Buffer.from(await extendedUtxo.hex, 'hex');
+
+    transaction.updateInput(transaction.inputsLength - 1, {
+      nonWitnessUtxo,
+    });
+  }
+
   async prepareInputs(transaction: btc.Transaction, options: SignOptions): Promise<void> {
     const { ledgerTransport } = options;
     if (!ledgerTransport) {
       throw new Error('Transport is required for Ledger signing');
     }
-
-    await this.addNonWitnessUtxosToInputs(transaction, options, this._p2wpkh.script);
 
     const app = new AppClient(ledgerTransport);
     const masterFingerPrint = await app.getMasterFingerprint();
@@ -530,6 +507,8 @@ export class LedgerP2trAddressContext extends P2trAddressContext {
   async addInput(transaction: btc.Transaction, extendedUtxo: ExtendedUtxo, options?: CompilationOptions) {
     const utxo = extendedUtxo.utxo;
 
+    const nonWitnessUtxo = Buffer.from(await extendedUtxo.hex, 'hex');
+
     transaction.addInput({
       txid: utxo.txid,
       index: utxo.vout,
@@ -537,6 +516,7 @@ export class LedgerP2trAddressContext extends P2trAddressContext {
         script: this._p2tr.script,
         amount: BigInt(utxo.value),
       },
+      nonWitnessUtxo,
       tapInternalKey: this._p2tr.tapInternalKey,
       sequence: options?.rbfEnabled ? 0xfffffffd : 0xffffffff,
     });
@@ -547,8 +527,6 @@ export class LedgerP2trAddressContext extends P2trAddressContext {
     if (!ledgerTransport) {
       throw new Error('Transport is required for Ledger signing');
     }
-
-    await this.addNonWitnessUtxosToInputs(transaction, options, this._p2tr.script);
 
     const app = new AppClient(ledgerTransport);
     const masterFingerPrint = await app.getMasterFingerprint();


### PR DESCRIPTION
# 🔘 PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

# 📜 Background
Ledger requires nonWitnessUtxo to be set for segwit inputs in order to not display the non-verified input warning message. However, adding the value results in a PSBT with a slightly different structure, which some integrating apps don't like and they reject the signed PSBT.

# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [x] No, Adds functionality (backwards compatible)
- [ ] No, Bug fixes (backwards compatible)

Changes:

- We now only inject the nonWitnessUtxo value when manually adding inputs into transactions. This means that we won't add it when signing external PSBTs.

Impact:

- This should allow you to purchase from marketplaces again

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
