### PR TITLE
fix: use stacks poxAddressToTuple instead of custom mapping to convert address to tuple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@stacks/connect": "^7.4.1",
         "@stacks/encryption": "6.9.0",
         "@stacks/network": "6.8.1",
+        "@stacks/stacking": "^6.12.0",
         "@stacks/storage": "^6.9.0",
         "@stacks/transactions": "6.9.0",
         "@stacks/wallet-sdk": "^6.9.0",
@@ -485,9 +486,9 @@
       }
     },
     "node_modules/@stacks/common": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.8.1.tgz",
-      "integrity": "sha512-ewL9GLZNQYa5a/3K4xSHlHIgHkD4rwWW/QEaPId8zQIaL+1O9qCaF4LX9orNQeOmEk8kvG0x2xGV54fXKCZeWQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.10.0.tgz",
+      "integrity": "sha512-6x5Z7AKd9/kj3+DYE9xIDIkFLHihBH614i2wqrZIjN02WxVo063hWSjIlUxlx8P4gl6olVzlOy5LzhLJD9OP0A==",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "@types/node": "^18.0.4"
@@ -551,6 +552,74 @@
         "schema-inspector": "^2.0.2",
         "zone-file": "^2.0.0-beta.3"
       }
+    },
+    "node_modules/@stacks/stacking": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/stacking/-/stacking-6.12.0.tgz",
+      "integrity": "sha512-XBxwbaCGRPnjpjspb3CBXrlZl6xR+gghLMz9PQNPdpuIbBDFa0SGeHgqjtpVU+2DVL4UyBx8PVsAWtlssyVGng==",
+      "dependencies": {
+        "@scure/base": "1.1.1",
+        "@stacks/common": "^6.10.0",
+        "@stacks/encryption": "^6.12.0",
+        "@stacks/network": "^6.11.3",
+        "@stacks/stacks-blockchain-api-types": "^0.61.0",
+        "@stacks/transactions": "^6.12.0",
+        "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/encryption": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/encryption/-/encryption-6.12.0.tgz",
+      "integrity": "sha512-CubE51pHrcxx3yA+xapevPgA9UDleIoEaUZ06/9uD91B42yvTg37HyS8t06rzukU9q+X7Cv2I/+vbuf4nJIo8g==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip39": "1.1.0",
+        "@stacks/common": "^6.10.0",
+        "@types/node": "^18.0.4",
+        "base64-js": "^1.5.1",
+        "bs58": "^5.0.0",
+        "ripemd160-min": "^0.0.6",
+        "varuint-bitcoin": "^1.1.2"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/network": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.11.3.tgz",
+      "integrity": "sha512-c4ClCU/QUwuu8NbHtDKPJNa0M5YxauLN3vYaR0+S4awbhVIKFQSxirm9Q9ckV1WBh7FtD6u2S0x+tDQGAODjNg==",
+      "dependencies": {
+        "@stacks/common": "^6.10.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/stacking/node_modules/@stacks/transactions": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.12.0.tgz",
+      "integrity": "sha512-gRP3SfTaAIoTdjMvOiLrMZb/senqB8JQlT5Y4C3/CiHhiprYwTx7TbOCSa7WsNOU99H4aNfHvatmymuggXQVkA==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^6.10.0",
+        "@stacks/network": "^6.11.3",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "node_modules/@stacks/stacks-blockchain-api-types": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-0.61.0.tgz",
+      "integrity": "sha512-yPOfTUboo5eA9BZL/hqMcM71GstrFs9YWzOrJFPeP4cOO1wgYvAcckgBRbgiE3NqeX0A7SLZLDAXLZbATuRq9w=="
     },
     "node_modules/@stacks/storage": {
       "version": "6.9.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@stacks/connect": "^7.4.1",
     "@stacks/encryption": "6.9.0",
     "@stacks/network": "6.8.1",
+    "@stacks/stacking": "^6.12.0",
     "@stacks/storage": "^6.9.0",
     "@stacks/transactions": "6.9.0",
     "@stacks/wallet-sdk": "^6.9.0",

--- a/transactions/stacking.ts
+++ b/transactions/stacking.ts
@@ -17,6 +17,7 @@ import BN from 'bn.js';
 import { StacksNetwork, StacksTransaction, StxMempoolTransactionData } from '../types';
 import { getNewNonce } from './helper';
 import { estimateContractCallFees, generateUnsignedContractCall, getNonce, setFee, setNonce } from './stx';
+import { poxAddressToTuple } from '@stacks/stacking';
 
 function getAddressHashMode(btcAddress: string) {
   if (btcAddress.startsWith('bc1') || btcAddress.startsWith('tb1')) {
@@ -68,6 +69,9 @@ interface TupleCV<T extends TupleData = TupleData> {
   data: T;
 }
 
+/**
+ * @deprecated use poxAddressToTuple from @stacks/transactions
+ */
 export function addressToVersionHashbyteTupleCV(btcAddress: string): TupleCV<TupleData<BufferCV>> {
   const { hashMode, data } = decodeBtcAddress(btcAddress);
   const hashModeBuffer = bufferCV(new BN(hashMode, 10).toBuffer());
@@ -91,8 +95,8 @@ export async function generateUnsignedDelegateTransaction(
   poolPoxAddress: string,
 ): Promise<StacksTransaction> {
   let unsignedTx;
-  const poolRewardAddressTuple = addressToVersionHashbyteTupleCV(poolPoxAddress);
-  const userRewardAddressTuple = addressToVersionHashbyteTupleCV(rewardAddress);
+  const poolRewardAddressTuple = poxAddressToTuple(poolPoxAddress);
+  const userRewardAddressTuple = poxAddressToTuple(rewardAddress);
 
   try {
     unsignedTx = await generateUnsignedContractCall({


### PR DESCRIPTION
# 🔘 PR Type


- Bugfix

# 📜 Background

This PR fixes an issue where address changed their format when converting to tuple 

Issue Link: #[ENG-3841](https://linear.app/xverseapp/issue/ENG-3841/wrong-reward-address-after-user-submit-the-delegation-tx)


# 🔄 Changes

Does this PR introduce a breaking change?

- [ ] Yes, Incompatible API changes
- [ ] No, Adds functionality (backwards compatible)
- [x] No, Bug fixes (backwards compatible)

Changes:

- use poxAddressToTuple from @stacks/stacking and add deprecate tag to addressToVersionHashbyteTupleCV

Impact:

- generation of unsigned delegation tx

# ✅ Review checklist

Please ensure the following are true before merging:

- [ ] Code Style is consistent with the project guidelines.
- [ ] Code is readable and well-commented.
- [ ] No unnecessary or debugging code has been added.
- [ ] Security considerations have been taken into account.
- [ ] The change has been manually tested and works as expected.
- [ ] Breaking changes and their impacts have been considered and documented.
- [ ] Code does not introduce new technical debt or issues.
